### PR TITLE
fix(runner): patch sandcastle to reuse worktree on tide run re-run

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@ai-hero/sandcastle@0.5.6": "patches/@ai-hero%2Fsandcastle@0.5.6.patch",
+  },
   "packages": {
     "@ai-hero/sandcastle": ["@ai-hero/sandcastle@0.5.6", "", { "dependencies": { "@clack/prompts": "^1.1.0", "@effect/cli": "^0.74.0", "@effect/platform": "^0.95.0", "@effect/platform-node": "^0.105.0", "@effect/printer": "^0.48.0", "@effect/printer-ansi": "^0.48.0", "effect": "^3.20.0" }, "peerDependencies": { "@daytona/sdk": "^0.164.0", "@vercel/sandbox": ">=1.0.0" }, "optionalPeers": ["@daytona/sdk", "@vercel/sandbox"], "bin": { "sandcastle": "dist/main.js" } }, "sha512-HGbDRBdu2xLWChnYAyjnVb9G4AvS7joUjHrLd0+6r3jjyMmb6+EZyO/UnLPa0BdJE3MlWW8XTjPSldxICtsZHw=="],
 

--- a/flake.nix
+++ b/flake.nix
@@ -34,9 +34,12 @@
             src = ./.;
             filter = path: type:
               let
-                base = baseNameOf (toString path);
+                relPath = pkgs.lib.removePrefix (toString ./. + "/") (toString path);
               in
-              base == "package.json" || base == "bun.lock";
+              relPath == "package.json"
+              || relPath == "bun.lock"
+              || relPath == "patches"
+              || pkgs.lib.hasPrefix "patches/" relPath;
           };
 
           nativeBuildInputs = [ pkgs.bun pkgs.cacert ];
@@ -72,7 +75,7 @@
           # `bun.lock` changes — `nix build` will print the new hash on
           # mismatch. To force a re-derivation, swap this for
           # `pkgs.lib.fakeSha256` and rerun `nix build`.
-          outputHash = "sha256-1G+3doviAYR4yDWieLfiSi7du+znu0c350FzYOHLHU4=";
+          outputHash = "sha256-IXjdJYgUXWcX6/PGy/jc3EDgEzBl2+5zE14XObEgt+k=";
         };
 
         tide = pkgs.stdenv.mkDerivation {

--- a/package.json
+++ b/package.json
@@ -27,5 +27,8 @@
   },
   "peerDependencies": {
     "typescript": "^5"
+  },
+  "patchedDependencies": {
+    "@ai-hero/sandcastle@0.5.6": "patches/@ai-hero%2Fsandcastle@0.5.6.patch"
   }
 }

--- a/patches/@ai-hero%2Fsandcastle@0.5.6.patch
+++ b/patches/@ai-hero%2Fsandcastle@0.5.6.patch
@@ -1,0 +1,22 @@
+diff --git a/dist/WorktreeManager.js b/dist/WorktreeManager.js
+index 61fbc343cc1ab61cdaa73e208c78259a8a230e5e..2257d6b7d0fa06e6704d1aea81af971a8600ee6c 100644
+--- a/dist/WorktreeManager.js
++++ b/dist/WorktreeManager.js
+@@ -118,8 +118,16 @@ export const create = (repoDir, opts) => Effect.gen(function* () {
+         const collision = existing.find((wt) => wt.branch === branch) ??
+             existing.find((wt) => wt.path === worktreePath);
+         if (collision) {
++            // `git worktree list` canonicalizes paths via realpath. If repoDir
++            // or .sandcastle is a symlink, the un-canonicalized prefix never
++            // matches and a sandcastle-owned worktree looks external. Resolve
++            // the prefix so the startsWith check accepts either form.
++            const realWorktreesDir = yield* fs
++                .realPath(worktreesDir)
++                .pipe(Effect.catchAll(() => Effect.succeed(worktreesDir)));
+             // Only reuse worktrees managed by sandcastle (under .sandcastle/worktrees/)
+-            const isManagedWorktree = collision.path.startsWith(worktreesDir);
++            const isManagedWorktree = collision.path.startsWith(worktreesDir) ||
++                collision.path.startsWith(realWorktreesDir);
+             if (isManagedWorktree) {
+                 const dirty = yield* hasUncommittedChanges(collision.path);
+                 if (dirty) {

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,64 @@
+# Vendored patches
+
+Patches in this directory are applied via Bun's `patchedDependencies` (see
+`package.json`). `bun install` re-applies them on every install; nothing else
+in the workflow needs to change.
+
+## `@ai-hero/sandcastle@0.5.6`
+
+### Symptom
+
+Re-running `tide run` on the same parent issue (same Linear-derived
+`branchName`) errored at worktree creation:
+
+> Branch '<b>' is already checked out in worktree at '<path>'. Use a different
+> branch name, or wait for the other run to finish.
+
+The user had to `git worktree remove` the previous run's worktree by hand
+before retrying.
+
+### Cause
+
+Tide bridges sandcastle's hardcoded `<repo>/.sandcastle/` directory to
+`<repo>/.tide/` with a relative symlink (`ensureSandcastleSymlink` in
+`src/cli/run.ts`). `git worktree list --porcelain` canonicalizes paths via
+realpath, so a managed worktree comes back as `<repo>/.tide/worktrees/...`.
+
+Sandcastle's `WorktreeManager.create` decides whether a colliding worktree is
+sandcastle-managed (and therefore reusable) by `startsWith` against the
+un-canonicalized `<repo>/.sandcastle/worktrees` prefix. Through the symlink
+that check fails, the worktree is treated as external, and create throws
+instead of reusing.
+
+`pruneStale` in the same file already canonicalizes the prefix via
+`fs.realPath` before comparing — `create` was simply missed.
+
+### The patch
+
+In `WorktreeManager.create`, when a collision is found, resolve `worktreesDir`
+through `fs.realPath` (with a fallback to the raw path on error, mirroring
+`pruneStale`'s pattern) and accept a collision path that starts with either
+the raw or canonicalized prefix when deciding `isManagedWorktree`. ~5 LOC.
+
+### Why patch instead of waiting
+
+Upstream's `pruneStale` got the same fix in 0.5.6 — `create` was overlooked
+and the symptom only surfaces with a symlinked `.sandcastle/`. Carrying a
+small patch unblocks resume-on-re-run today; waiting on upstream means every
+aborted run requires manual cleanup.
+
+### Deletion criteria
+
+When upstream sandcastle ships the same canonicalization in `create`:
+
+1. Bump the version pin in `package.json` past the fix.
+2. Delete the `patchedDependencies` entry for `@ai-hero/sandcastle`.
+3. Delete this patch file.
+
+### Manual smoke after a sandcastle bump
+
+1. `tide run` against any parent issue with at least one open sub-issue.
+2. Abort partway (Ctrl-C, or let an iteration fail).
+3. Re-run `tide run` on the same parent.
+4. Confirm sandcastle logs `Reusing existing worktree at <path> (branch
+'<branch>')` instead of throwing the "already checked out" error.

--- a/src/runner/worktree-reuse.test.ts
+++ b/src/runner/worktree-reuse.test.ts
@@ -1,0 +1,84 @@
+// Regression test for the patched @ai-hero/sandcastle WorktreeManager.create.
+//
+// Tide bridges `<repo>/.sandcastle` -> `<repo>/.tide` with a symlink so that
+// sandcastle's hardcoded `.sandcastle/worktrees/...` paths land under `.tide/`.
+// `git worktree list --porcelain` canonicalizes paths via realpath, so a
+// pre-existing managed worktree comes back with a `.tide/` prefix.
+//
+// Before the patch, sandcastle compared collisions against the un-canonicalized
+// `<repo>/.sandcastle/worktrees` prefix and treated the worktree as external,
+// causing re-runs on the same parent issue to throw `Branch '<b>' is already
+// checked out in worktree at '<path>'`. The patch resolves both prefixes and
+// accepts either.
+//
+// This test sets up the bridge exactly like `ensureSandcastleSymlink` does,
+// calls sandcastle's public `createWorktree` twice with the same branch, and
+// asserts the second call reuses rather than throws.
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createWorktree } from "@ai-hero/sandcastle";
+
+function git(repo: string, args: readonly string[]): void {
+  execFileSync("git", args as string[], { cwd: repo, stdio: "ignore" });
+}
+
+describe("sandcastle createWorktree under .sandcastle -> .tide symlink", () => {
+  let workDir: string;
+  let repoRoot: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "tide-worktree-reuse-"));
+    repoRoot = join(workDir, "repo");
+    mkdirSync(repoRoot, { recursive: true });
+
+    // Minimal git repo with one commit so worktree creation has a base ref.
+    git(repoRoot, ["init", "-q", "-b", "main"]);
+    git(repoRoot, ["config", "user.email", "test@example.com"]);
+    git(repoRoot, ["config", "user.name", "Test"]);
+    writeFileSync(join(repoRoot, "README.md"), "seed\n");
+    git(repoRoot, ["add", "README.md"]);
+    git(repoRoot, ["commit", "-q", "-m", "seed"]);
+
+    // Mirror ensureSandcastleSymlink: .sandcastle is a relative symlink to .tide.
+    mkdirSync(join(repoRoot, ".tide"), { recursive: true });
+    symlinkSync(".tide", join(repoRoot, ".sandcastle"), "dir");
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("second createWorktree on the same branch reuses the worktree", async () => {
+    const branch = "tide/reuse-test";
+
+    const first = await createWorktree({
+      cwd: repoRoot,
+      branchStrategy: { type: "branch", branch },
+    });
+
+    const second = await createWorktree({
+      cwd: repoRoot,
+      branchStrategy: { type: "branch", branch },
+    });
+
+    expect(second.branch).toBe(branch);
+    // First returns the un-canonicalized path it joined; second returns the
+    // realpath-canonicalized form from `git worktree list`. Both must resolve
+    // to the same physical worktree.
+    expect(realpathSync(second.worktreePath)).toBe(
+      realpathSync(first.worktreePath)
+    );
+
+    await first.close();
+  });
+});


### PR DESCRIPTION
## 🚩 The Problem

* Re-running `tide run` on the same parent issue threw `Branch '<b>' is already checked out in worktree at '<path>'`.
* User had to `git worktree remove` the prior run's worktree by hand to retry — resume-on-re-run never felt automatic.
* Root cause: sandcastle's `WorktreeManager.create` does `collision.path.startsWith(worktreesDir)` against an un-canonicalized prefix; tide's `.sandcastle → .tide` symlink makes `git worktree list`'s realpath'd output miss that check, so the worktree looks external and create throws.

## 💡 The Solution

* Vendor a ~5 LOC patch via Bun's `patchedDependencies` that resolves `worktreesDir` through `fs.realPath` (mirroring the existing `pruneStale` pattern) and accepts either prefix.
* Establish a `patches/` convention with a README documenting per-patch symptom, cause, and deletion criteria for when upstream catches up.
* No tide public-interface changes — purely a runtime behavior fix in a vendored dep. Adds a regression test that drives `createWorktree` twice through the same symlink bridge.

## 🏗 Architecture & Public Interface Changes

### 🗺 Interface Movements

| Interface / Symbol | Old Location / Status | New Location / Status | Notes |
| :--- | :--- | :--- | :--- |
| `tide run` re-run | Throws on worktree collision | Reuses managed worktree | Behavior fix; no tide API change |
| `patches/` | — | 🆕 New convention | Vendored-dep patches applied via Bun on every `bun install` |

### 📦 Package Breakdowns

#### 1. `patches/`

*New directory hosting Bun-applied patches against vendored dependencies. README documents per-patch symptom, cause, deletion criteria, and post-bump smoke steps.*

<details>
<summary>🔍 View Interface Changes (sandcastle WorktreeManager.create)</summary>

```diff
+ const realWorktreesDir = yield* fs
+   .realPath(worktreesDir)
+   .pipe(Effect.catchAll(() => Effect.succeed(worktreesDir)));

- const isManagedWorktree = collision.path.startsWith(worktreesDir);
+ const isManagedWorktree =
+   collision.path.startsWith(worktreesDir) ||
+   collision.path.startsWith(realWorktreesDir);
```

</details>

<sub>**Files changed:** [`@ai-hero%2Fsandcastle@0.5.6.patch`](https://github.com/m1yon/tide/pull/16/files#diff-12cdb983470e7e11beb9b5e7cf7049fed48278c88f1a47d17fe202c1b7da2170), [`README.md`](https://github.com/m1yon/tide/pull/16/files#diff-2f6cada697a2dedd209c80776de7abbdac6caa3e2b935afa20ff149df2e8cda2)</sub>

---

#### 2. `src/runner/`

*Regression test that mirrors `ensureSandcastleSymlink` (creates `.sandcastle → .tide` symlink in a temp git repo) and asserts `createWorktree` on the same branch returns a reused worktree on the second call instead of throwing.*

<sub>**Files changed:** [`worktree-reuse.test.ts`](https://github.com/m1yon/tide/pull/16/files#diff-2f52a5412329701b72a448908e84dff27d7b18ee60e4c21074c6fbb4833be278)</sub>

---

#### 3. `/` (root)

*Wires the patch through Bun's `patchedDependencies` so `bun install` re-applies it on every install — no manual postinstall step.*

<sub>**Files changed:** [`package.json`](https://github.com/m1yon/tide/pull/16/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519), [`bun.lock`](https://github.com/m1yon/tide/pull/16/files#diff-bfd0ef82a01108fa1e836c2500b98b7de8a92bb1ae352a8efcbd9d6ffcaabd60)</sub>

## 🧹 Housekeeping & Secondary Changes

* None.

Closes #15
