### PR TITLE
feat: add PR-submission tail step to tide run

### DIFF
--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -99,6 +99,7 @@ describe("runPrTailStep", () => {
     baseBranch: "master",
     parentNumber: 7,
     parentTitle: "PRD: example feature",
+    subIssues: [{ number: 8, title: "Foundation tracer" }],
     repoRoot: "/repo",
     config: baseConfig,
     sandboxEnv: {},

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { tideRun } from "./run.ts";
+import type { ShellResult, ShellRunner } from "../pr-submission/index.ts";
+
+interface Sinks {
+  stdout: string[];
+  stderr: string[];
+  pushStdout: (s: string) => void;
+  pushStderr: (s: string) => void;
+}
+
+function makeSinks(): Sinks {
+  const sinks: Sinks = {
+    stdout: [],
+    stderr: [],
+    pushStdout: () => undefined,
+    pushStderr: () => undefined,
+  };
+  sinks.pushStdout = (s) => sinks.stdout.push(s);
+  sinks.pushStderr = (s) => sinks.stderr.push(s);
+  return sinks;
+}
+
+function constShellRunner(result: ShellResult): ShellRunner {
+  return () => Promise.resolve(result);
+}
+
+describe("tideRun base-branch capture", () => {
+  let workDir: string;
+  let repoRoot: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "tide-run-"));
+    repoRoot = join(workDir, "repo");
+    mkdirSync(join(repoRoot, ".git"), { recursive: true });
+    mkdirSync(join(repoRoot, ".tide"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("detached HEAD fails fast before any queue work runs", async () => {
+    const sinks = makeSinks();
+    const code = await tideRun({
+      repoRoot,
+      stdout: sinks.pushStdout,
+      stderr: sinks.pushStderr,
+      // Simulate `git rev-parse --abbrev-ref HEAD` returning "HEAD" — the
+      // sentinel git uses for detached-HEAD state.
+      baseBranchShellRunner: constShellRunner({
+        exitCode: 0,
+        stdout: "HEAD\n",
+        stderr: "",
+      }),
+    });
+
+    expect(code).toBe(1);
+    expect(sinks.stderr.join("")).toContain("detached HEAD");
+  });
+
+  test("git rev-parse failure also fails fast with a clear error", async () => {
+    const sinks = makeSinks();
+    const code = await tideRun({
+      repoRoot,
+      stdout: sinks.pushStdout,
+      stderr: sinks.pushStderr,
+      baseBranchShellRunner: constShellRunner({
+        exitCode: 128,
+        stdout: "",
+        stderr: "fatal: not a git repository",
+      }),
+    });
+
+    expect(code).toBe(1);
+    expect(sinks.stderr.join("")).toContain("git rev-parse");
+  });
+});

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -103,6 +103,9 @@ describe("runPrTailStep", () => {
     config: baseConfig,
     sandboxEnv: {},
     completedCount: 3,
+    // Default to non-zero so tests that don't care about the rev-list gate
+    // exercise the runPrSubmission path.
+    countCommitsAhead: () => Promise.resolve(5),
   };
 
   test("confirm=no: skips runPrSubmission, returns opted-out outcome with distinct outro", async () => {
@@ -129,6 +132,58 @@ describe("runPrTailStep", () => {
     expect(result.outroMessage).toContain("PR step skipped");
     expect(result.outroMessage).not.toContain("PR opened");
     expect(result.outroMessage).not.toContain("PR submission failed");
+  });
+
+  test("confirm=yes + zero commits ahead: skips runPrSubmission, returns skipped-empty outcome with distinct outro", async () => {
+    let prCalls = 0;
+    const runPrSubmission = (): Promise<PrSubmissionResult> => {
+      prCalls += 1;
+      return Promise.resolve({
+        url: "should-not-be-called",
+        action: "opened",
+      });
+    };
+
+    let countCalls = 0;
+    const countCommitsAhead = (): Promise<number> => {
+      countCalls += 1;
+      return Promise.resolve(0);
+    };
+
+    const result = await runPrTailStep({
+      ...baseInput,
+      prCreationConfirmed: true,
+      countCommitsAhead,
+      runPrSubmission,
+    });
+
+    expect(prCalls).toBe(0);
+    expect(countCalls).toBe(1);
+    expect(result.outcome).toEqual({ kind: "skipped-empty" });
+    expect(result.exitCode).toBe(0);
+    // Distinct outro: identifies zero-commits as the reason, not opt-out
+    // and not failure.
+    expect(result.outroMessage).toContain("PR step skipped");
+    expect(result.outroMessage).toContain("no commits ahead");
+    expect(result.outroMessage).not.toContain("opted out");
+    expect(result.outroMessage).not.toContain("PR submission failed");
+  });
+
+  test("confirm=no: rev-list gate is not run (opt-out short-circuits)", async () => {
+    let countCalls = 0;
+    const countCommitsAhead = (): Promise<number> => {
+      countCalls += 1;
+      return Promise.resolve(0);
+    };
+
+    const result = await runPrTailStep({
+      ...baseInput,
+      prCreationConfirmed: false,
+      countCommitsAhead,
+    });
+
+    expect(countCalls).toBe(0);
+    expect(result.outcome).toEqual({ kind: "opted-out" });
   });
 
   test("confirm=yes: invokes runPrSubmission and returns opened outcome", async () => {

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -2,8 +2,13 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdirSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { tideRun } from "./run.ts";
-import type { ShellResult, ShellRunner } from "../pr-submission/index.ts";
+import { runPrTailStep, tideRun } from "./run.ts";
+import type {
+  PrSubmissionResult,
+  ShellResult,
+  ShellRunner,
+} from "../pr-submission/index.ts";
+import type { TideConfig } from "../config-loader/index.ts";
 
 interface Sinks {
   stdout: string[];
@@ -77,5 +82,94 @@ describe("tideRun base-branch capture", () => {
 
     expect(code).toBe(1);
     expect(sinks.stderr.join("")).toContain("git rev-parse");
+  });
+});
+
+describe("runPrTailStep", () => {
+  const baseConfig: TideConfig = {
+    linear: { team: "ENG" },
+    sandbox: { mounts: [] },
+    hooks: { onSandboxReady: [] },
+  };
+  const baseGhRepo = { owner: "acme", repo: "widget" };
+
+  const baseInput = {
+    ghRepo: baseGhRepo,
+    branch: "feature/per-32",
+    baseBranch: "master",
+    parentNumber: 7,
+    parentTitle: "PRD: example feature",
+    repoRoot: "/repo",
+    config: baseConfig,
+    sandboxEnv: {},
+    completedCount: 3,
+  };
+
+  test("confirm=no: skips runPrSubmission, returns opted-out outcome with distinct outro", async () => {
+    let calls = 0;
+    const runPrSubmission = (): Promise<PrSubmissionResult> => {
+      calls += 1;
+      return Promise.resolve({
+        url: "should-not-be-called",
+        action: "opened",
+      });
+    };
+
+    const result = await runPrTailStep({
+      ...baseInput,
+      prCreationConfirmed: false,
+      runPrSubmission,
+    });
+
+    expect(calls).toBe(0);
+    expect(result.outcome).toEqual({ kind: "opted-out" });
+    expect(result.exitCode).toBe(0);
+    // Distinct outro: contains a recognizable opt-out marker, not the
+    // "PR opened" or "PR submission failed" wording used on other paths.
+    expect(result.outroMessage).toContain("PR step skipped");
+    expect(result.outroMessage).not.toContain("PR opened");
+    expect(result.outroMessage).not.toContain("PR submission failed");
+  });
+
+  test("confirm=yes: invokes runPrSubmission and returns opened outcome", async () => {
+    const runPrSubmission = (): Promise<PrSubmissionResult> =>
+      Promise.resolve({
+        url: "https://github.com/acme/widget/pull/42",
+        action: "opened",
+      });
+
+    const result = await runPrTailStep({
+      ...baseInput,
+      prCreationConfirmed: true,
+      runPrSubmission,
+    });
+
+    expect(result.outcome).toEqual({
+      kind: "opened",
+      url: "https://github.com/acme/widget/pull/42",
+    });
+    expect(result.exitCode).toBe(0);
+    expect(result.outroMessage).toContain("PR opened");
+    expect(result.outroMessage).toContain(
+      "https://github.com/acme/widget/pull/42"
+    );
+  });
+
+  test("confirm=yes but runPrSubmission throws: returns failed outcome with exitCode 1", async () => {
+    const runPrSubmission = (): Promise<PrSubmissionResult> =>
+      Promise.reject(new Error("push refused by remote"));
+
+    const result = await runPrTailStep({
+      ...baseInput,
+      prCreationConfirmed: true,
+      runPrSubmission,
+    });
+
+    expect(result.outcome.kind).toBe("failed");
+    if (result.outcome.kind === "failed") {
+      expect(result.outcome.message).toMatch(/push refused/);
+    }
+    expect(result.exitCode).toBe(1);
+    expect(result.outroMessage).toContain("PR submission failed");
   });
 });

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -1,12 +1,14 @@
 // `tide run` — full PRD-rooted, Linear-tracked agent flow.
 //
 // Steps:
-//   1. discover repo root → load config + env → resolve gh identity
+//   1. discover repo root → capture base branch (fail fast on detached HEAD)
+//      → load config + env → resolve gh identity
 //   2. fetch GitHub triage tree, single-select parent
 //   3. fetch descendant subtree → topo-sort via dep-graph
 //   4. resolve Linear issue (create-or-paste loop)
 //   5. preflight summary + Y/n confirm
 //   6. run Sandcastle iterations per sub-issue (single shared branch)
+//   7. on success: open a PR against the captured base branch
 //
 // The agent itself closes its sub-issue via the prompt template; the runner
 // makes no `gh issue close` call.
@@ -33,6 +35,13 @@ import {
 } from "../github/index.ts";
 import { getGhIdentity } from "../gh-identity/index.ts";
 import type { ParentForLinear } from "../linear/index.ts";
+import {
+  resolveBaseBranch,
+  runPrSubmission as defaultRunPrSubmission,
+  type PrSubmissionResult,
+  type RunPrSubmissionOptions,
+  type ShellRunner,
+} from "../pr-submission/index.ts";
 import { discoverRepoRoot } from "../repo-discovery/index.ts";
 import { runIssueQueue } from "../runner/index.ts";
 import { pickParent, resolveLinearIssue } from "../selector/index.ts";
@@ -42,6 +51,19 @@ export interface RunOptions {
   repoRoot?: string;
   stdout?: (chunk: string) => void;
   stderr?: (chunk: string) => void;
+  /**
+   * Test seam: shell runner used for the host-side base-branch capture
+   * (`git rev-parse --abbrev-ref HEAD`). Defaults to a child_process spawn
+   * inside the pr-submission module.
+   */
+  baseBranchShellRunner?: ShellRunner;
+  /**
+   * Test seam: PR submission entry point. Tests can stub this to avoid
+   * actually pushing or invoking Sandcastle.
+   */
+  runPrSubmission?: (
+    options: RunPrSubmissionOptions
+  ) => Promise<PrSubmissionResult>;
 }
 
 /**
@@ -80,6 +102,22 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
   let repoRoot: string;
   try {
     repoRoot = options.repoRoot ?? discoverRepoRoot();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    stderr(`${msg}\n`);
+    return 1;
+  }
+
+  // Capture the base branch *before* any other work. This is the branch the
+  // user invoked `tide run` from — it becomes the base for the PR opened at
+  // the tail of the run. Failing fast on detached HEAD here avoids burning a
+  // queue's worth of work only to discover the PR step can't proceed.
+  let baseBranch: string;
+  try {
+    baseBranch = await resolveBaseBranch(
+      repoRoot,
+      options.baseBranchShellRunner
+    );
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     stderr(`${msg}\n`);
@@ -297,8 +335,33 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
     return 1;
   }
 
+  // Queue succeeded — submit a PR for the branch against the base branch the
+  // user was on at invocation. Sub-issue #8 of PRD #7: foundation tracer
+  // (placeholder body, "opened" path only).
+  const runPrSubmissionFn = options.runPrSubmission ?? defaultRunPrSubmission;
+  let prResult: PrSubmissionResult;
+  try {
+    prResult = await runPrSubmissionFn({
+      ghRepo,
+      branch: linear.branchName,
+      baseBranch,
+      parentNumber: picked.root.number,
+      parentTitle: picked.root.title,
+      repoRoot,
+      config,
+      sandboxEnv,
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    log.error(msg);
+    outro(
+      `Done. Completed ${String(runResult.completed)} issue(s) on ${linear.branchName}, but PR submission failed.`
+    );
+    return 1;
+  }
+
   outro(
-    `Done. Completed ${String(runResult.completed)} issue(s) on ${linear.branchName}.`
+    `Done. Completed ${String(runResult.completed)} issue(s) on ${linear.branchName}. PR opened: ${prResult.url}`
   );
   return 0;
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -36,6 +36,7 @@ import {
 import { getGhIdentity } from "../gh-identity/index.ts";
 import type { ParentForLinear } from "../linear/index.ts";
 import {
+  countCommitsAhead as defaultCountCommitsAhead,
   resolveBaseBranch,
   runPrSubmission as defaultRunPrSubmission,
   type PrSubmissionResult,
@@ -81,10 +82,17 @@ export interface RunPrTailStepOptions {
   runPrSubmission?: (
     options: RunPrSubmissionOptions
   ) => Promise<PrSubmissionResult>;
+  /** Test seam — defaults to the imported `countCommitsAhead`. */
+  countCommitsAhead?: (
+    repoRoot: string,
+    baseBranch: string,
+    branch: string
+  ) => Promise<number>;
 }
 
 export type PrTailOutcome =
   | { kind: "opted-out" }
+  | { kind: "skipped-empty" }
   | { kind: "opened"; url: string }
   | { kind: "failed"; message: string };
 
@@ -110,6 +118,38 @@ export async function runPrTailStep(
     return {
       outcome: { kind: "opted-out" },
       outroMessage: `Done. ${completedSummary}. PR step skipped (you opted out at pre-flight).`,
+      exitCode: 0,
+    };
+  }
+
+  // Rev-list gate: if the branch is not ahead of base, there is nothing to
+  // submit. Run after the opt-out check so we don't shell out when the user
+  // already declined.
+  const countCommitsAheadFn =
+    opts.countCommitsAhead ?? defaultCountCommitsAhead;
+  let commitsAhead: number;
+  try {
+    commitsAhead = await countCommitsAheadFn(
+      opts.repoRoot,
+      opts.baseBranch,
+      opts.branch
+    );
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      outcome: { kind: "failed", message },
+      outroMessage: `Done. ${completedSummary}, but PR submission failed.`,
+      exitCode: 1,
+    };
+  }
+
+  if (commitsAhead === 0) {
+    log.warn(
+      `Branch ${opts.branch} has no commits ahead of ${opts.baseBranch}. Skipping PR step — there is nothing to submit.`
+    );
+    return {
+      outcome: { kind: "skipped-empty" },
+      outroMessage: `Done. ${completedSummary}. PR step skipped (no commits ahead of ${opts.baseBranch}).`,
       exitCode: 0,
     };
   }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -66,6 +66,81 @@ export interface RunOptions {
   ) => Promise<PrSubmissionResult>;
 }
 
+export interface RunPrTailStepOptions {
+  prCreationConfirmed: boolean;
+  ghRepo: GhRepo;
+  branch: string;
+  baseBranch: string;
+  parentNumber: number;
+  parentTitle: string;
+  repoRoot: string;
+  config: TideConfig;
+  sandboxEnv: Record<string, string>;
+  completedCount: number;
+  /** Test seam — defaults to the imported `runPrSubmission`. */
+  runPrSubmission?: (
+    options: RunPrSubmissionOptions
+  ) => Promise<PrSubmissionResult>;
+}
+
+export type PrTailOutcome =
+  | { kind: "opted-out" }
+  | { kind: "opened"; url: string }
+  | { kind: "failed"; message: string };
+
+export interface PrTailStepResult {
+  outcome: PrTailOutcome;
+  outroMessage: string;
+  exitCode: 0 | 1;
+}
+
+/**
+ * Decide and execute the post-queue PR-submission tail step. Returns the
+ * outro message and exit code so the caller (tideRun) can render UI
+ * uniformly. The caller is expected to short-circuit on aborted runs before
+ * invoking this helper; the only skip path handled here is the user's
+ * pre-flight opt-out.
+ */
+export async function runPrTailStep(
+  opts: RunPrTailStepOptions
+): Promise<PrTailStepResult> {
+  const completedSummary = `Completed ${String(opts.completedCount)} issue(s) on ${opts.branch}`;
+
+  if (!opts.prCreationConfirmed) {
+    return {
+      outcome: { kind: "opted-out" },
+      outroMessage: `Done. ${completedSummary}. PR step skipped (you opted out at pre-flight).`,
+      exitCode: 0,
+    };
+  }
+
+  const runPrSubmissionFn = opts.runPrSubmission ?? defaultRunPrSubmission;
+  try {
+    const prResult = await runPrSubmissionFn({
+      ghRepo: opts.ghRepo,
+      branch: opts.branch,
+      baseBranch: opts.baseBranch,
+      parentNumber: opts.parentNumber,
+      parentTitle: opts.parentTitle,
+      repoRoot: opts.repoRoot,
+      config: opts.config,
+      sandboxEnv: opts.sandboxEnv,
+    });
+    return {
+      outcome: { kind: "opened", url: prResult.url },
+      outroMessage: `Done. ${completedSummary}. PR opened: ${prResult.url}`,
+      exitCode: 0,
+    };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return {
+      outcome: { kind: "failed", message },
+      outroMessage: `Done. ${completedSummary}, but PR submission failed.`,
+      exitCode: 1,
+    };
+  }
+}
+
 /**
  * Ensure that Sandcastle's hardcoded `.sandcastle/` directory points at the
  * tide-conventional `.tide/`. Sandcastle writes worktrees and logs under
@@ -307,6 +382,15 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
     return 0;
   }
 
+  // Pre-flight opt-out for the tail PR step. Captured here (not at the tail)
+  // so the run remains autonomous after kickoff. Cancelling the prompt is
+  // treated like answering "no".
+  const prCreationAnswer = await confirm({
+    message: "Create a PR at the end?",
+    initialValue: true,
+  });
+  const prCreationConfirmed = !isCancel(prCreationAnswer) && prCreationAnswer;
+
   const orderedForRunner = result.order.map((n) => ({
     number: n,
     title: titlesByNumber.get(n) ?? `#${String(n)}`,
@@ -335,33 +419,27 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
     return 1;
   }
 
-  // Queue succeeded — submit a PR for the branch against the base branch the
-  // user was on at invocation. Sub-issue #8 of PRD #7: foundation tracer
-  // (placeholder body, "opened" path only).
-  const runPrSubmissionFn = options.runPrSubmission ?? defaultRunPrSubmission;
-  let prResult: PrSubmissionResult;
-  try {
-    prResult = await runPrSubmissionFn({
-      ghRepo,
-      branch: linear.branchName,
-      baseBranch,
-      parentNumber: picked.root.number,
-      parentTitle: picked.root.title,
-      repoRoot,
-      config,
-      sandboxEnv,
-    });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error(msg);
-    outro(
-      `Done. Completed ${String(runResult.completed)} issue(s) on ${linear.branchName}, but PR submission failed.`
-    );
-    return 1;
-  }
+  // Queue succeeded — hand the post-queue decision to the tail-step helper,
+  // which gates on the pre-flight PR confirm and (if confirmed) invokes the
+  // PR-submission module. The helper returns the outro message + exit code
+  // so opt-out, opened, and failed paths render uniformly here.
+  const tail = await runPrTailStep({
+    prCreationConfirmed,
+    ghRepo,
+    branch: linear.branchName,
+    baseBranch,
+    parentNumber: picked.root.number,
+    parentTitle: picked.root.title,
+    repoRoot,
+    config,
+    sandboxEnv,
+    completedCount: runResult.completed,
+    runPrSubmission: options.runPrSubmission,
+  });
 
-  outro(
-    `Done. Completed ${String(runResult.completed)} issue(s) on ${linear.branchName}. PR opened: ${prResult.url}`
-  );
-  return 0;
+  if (tail.outcome.kind === "failed") {
+    log.error(tail.outcome.message);
+  }
+  outro(tail.outroMessage);
+  return tail.exitCode;
 }

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -42,6 +42,7 @@ import {
   type PrSubmissionResult,
   type RunPrSubmissionOptions,
   type ShellRunner,
+  type SubIssueRef,
 } from "../pr-submission/index.ts";
 import { discoverRepoRoot } from "../repo-discovery/index.ts";
 import { runIssueQueue } from "../runner/index.ts";
@@ -74,6 +75,8 @@ export interface RunPrTailStepOptions {
   baseBranch: string;
   parentNumber: number;
   parentTitle: string;
+  /** Topo-ordered sub-issues addressed by this PR. */
+  subIssues: SubIssueRef[];
   repoRoot: string;
   config: TideConfig;
   sandboxEnv: Record<string, string>;
@@ -162,6 +165,7 @@ export async function runPrTailStep(
       baseBranch: opts.baseBranch,
       parentNumber: opts.parentNumber,
       parentTitle: opts.parentTitle,
+      subIssues: opts.subIssues,
       repoRoot: opts.repoRoot,
       config: opts.config,
       sandboxEnv: opts.sandboxEnv,
@@ -470,6 +474,7 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
     baseBranch,
     parentNumber: picked.root.number,
     parentTitle: picked.root.title,
+    subIssues: orderedForRunner,
     repoRoot,
     config,
     sandboxEnv,

--- a/src/pr-submission/index.test.ts
+++ b/src/pr-submission/index.test.ts
@@ -1,0 +1,287 @@
+import { describe, it, expect } from "bun:test";
+import {
+  resolveBaseBranch,
+  runPrSubmission,
+  type ShellResult,
+  type ShellRunner,
+  type SandcastleRun,
+} from "./index.ts";
+import type { TideConfig } from "../config-loader/index.ts";
+import type { RunResult } from "@ai-hero/sandcastle";
+
+interface ShellCall {
+  cmd: string;
+  args: readonly string[];
+  cwd: string;
+}
+
+interface ShellStubEntry {
+  match: (call: ShellCall) => boolean;
+  result: ShellResult;
+}
+
+function buildShellRunner(stubs: ShellStubEntry[]): {
+  runner: ShellRunner;
+  calls: ShellCall[];
+} {
+  const calls: ShellCall[] = [];
+  const runner: ShellRunner = (cmd, args, cwd) => {
+    const call: ShellCall = { cmd, args: [...args], cwd };
+    calls.push(call);
+    const stub = stubs.find((s) => s.match(call));
+    if (!stub) {
+      return Promise.reject(
+        new Error(`unstubbed shell call: ${cmd} ${args.join(" ")} (cwd=${cwd})`)
+      );
+    }
+    return Promise.resolve(stub.result);
+  };
+  return { runner, calls };
+}
+
+async function captureError<T>(p: Promise<T>): Promise<unknown> {
+  try {
+    await p;
+    return null;
+  } catch (e) {
+    return e;
+  }
+}
+
+const baseConfig: TideConfig = {
+  linear: { team: "ENG" },
+  sandbox: { mounts: [] },
+  hooks: { onSandboxReady: [] },
+};
+
+const baseGhRepo = { owner: "acme", repo: "widget" };
+
+const baseSandcastleRun: SandcastleRun = () =>
+  Promise.resolve({
+    iterations: [],
+    stdout: "",
+    commits: [],
+    branch: "feature/foo",
+  } satisfies RunResult);
+
+describe("resolveBaseBranch", () => {
+  it("returns the trimmed branch name on success", async () => {
+    const { runner } = buildShellRunner([
+      {
+        match: (c) =>
+          c.cmd === "git" && c.args.join(" ") === "rev-parse --abbrev-ref HEAD",
+        result: { exitCode: 0, stdout: "main\n", stderr: "" },
+      },
+    ]);
+    const branch = await resolveBaseBranch("/tmp/repo", runner);
+    expect(branch).toBe("main");
+  });
+
+  it("throws a clear error on detached HEAD (output 'HEAD')", async () => {
+    const { runner } = buildShellRunner([
+      {
+        match: (c) =>
+          c.cmd === "git" && c.args.join(" ") === "rev-parse --abbrev-ref HEAD",
+        result: { exitCode: 0, stdout: "HEAD\n", stderr: "" },
+      },
+    ]);
+    const err = await captureError(resolveBaseBranch("/tmp/repo", runner));
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/detached HEAD/);
+  });
+
+  it("throws when git rev-parse exits non-zero", async () => {
+    const { runner } = buildShellRunner([
+      {
+        match: (c) => c.cmd === "git",
+        result: { exitCode: 128, stdout: "", stderr: "fatal: not a git repo" },
+      },
+    ]);
+    const err = await captureError(resolveBaseBranch("/tmp/repo", runner));
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/git rev-parse.*failed/);
+  });
+});
+
+describe("runPrSubmission", () => {
+  it("happy path: pushes the branch, fires the iteration, verifies via gh pr list, returns opened+url", async () => {
+    const { runner, calls } = buildShellRunner([
+      {
+        match: (c) => c.cmd === "git" && c.args[0] === "push",
+        result: { exitCode: 0, stdout: "", stderr: "" },
+      },
+      {
+        match: (c) =>
+          c.cmd === "gh" && c.args[0] === "pr" && c.args[1] === "list",
+        result: {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            { number: 42, url: "https://github.com/acme/widget/pull/42" },
+          ]),
+          stderr: "",
+        },
+      },
+    ]);
+
+    let receivedRunOptions: Parameters<SandcastleRun>[0] | undefined;
+    const sandcastleRun: SandcastleRun = (opts) => {
+      receivedRunOptions = opts;
+      return Promise.resolve({
+        iterations: [],
+        stdout: "",
+        commits: [],
+        branch: "feature/per-32",
+      } satisfies RunResult);
+    };
+
+    const result = await runPrSubmission({
+      ghRepo: baseGhRepo,
+      branch: "feature/per-32",
+      baseBranch: "master",
+      parentNumber: 7,
+      parentTitle: "PRD: example feature",
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      shellRunner: runner,
+      sandcastleRun,
+    });
+
+    expect(result).toEqual({
+      url: "https://github.com/acme/widget/pull/42",
+      action: "opened",
+    });
+
+    // Push happened first.
+    expect(calls[0]?.cmd).toBe("git");
+    expect(calls[0]?.args).toEqual(["push", "-u", "origin", "feature/per-32"]);
+    expect(calls[0]?.cwd).toBe("/repo");
+
+    // The iteration was fired with the right shape.
+    expect(receivedRunOptions).toBeDefined();
+    if (!receivedRunOptions) throw new Error("missing run options");
+    expect(receivedRunOptions.maxIterations).toBe(1);
+    expect(receivedRunOptions.branchStrategy).toEqual({
+      type: "branch",
+      branch: "feature/per-32",
+    });
+    expect(typeof receivedRunOptions.prompt).toBe("string");
+    expect(receivedRunOptions.promptFile).toBeUndefined();
+    // Placeholder body must close the parent PRD.
+    expect(receivedRunOptions.prompt).toContain("Closes #7");
+    // Branch and base must be substituted.
+    expect(receivedRunOptions.prompt).toContain("feature/per-32");
+    expect(receivedRunOptions.prompt).toContain("master");
+    // Repo identifier is injected so the agent can pass --repo correctly.
+    expect(receivedRunOptions.prompt).toContain("acme/widget");
+
+    // gh pr list ran with --head <branch>.
+    const ghCall = calls.find((c) => c.cmd === "gh");
+    expect(ghCall?.args).toContain("--head");
+    expect(ghCall?.args).toContain("feature/per-32");
+    expect(ghCall?.args).toContain("--json");
+    expect(ghCall?.args).toContain("number,url");
+  });
+
+  it("throws when git push fails — never reaches the iteration", async () => {
+    let sandcastleCalled = false;
+    const sandcastleRun: SandcastleRun = () => {
+      sandcastleCalled = true;
+      return baseSandcastleRun({} as Parameters<SandcastleRun>[0]);
+    };
+
+    const { runner } = buildShellRunner([
+      {
+        match: (c) => c.cmd === "git" && c.args[0] === "push",
+        result: {
+          exitCode: 1,
+          stdout: "",
+          stderr: "remote: Permission to acme/widget.git denied",
+        },
+      },
+    ]);
+
+    const err = await captureError(
+      runPrSubmission({
+        ghRepo: baseGhRepo,
+        branch: "feature/per-32",
+        baseBranch: "master",
+        parentNumber: 7,
+        parentTitle: "PRD",
+        repoRoot: "/repo",
+        config: baseConfig,
+        sandboxEnv: {},
+        shellRunner: runner,
+        sandcastleRun,
+      })
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/git push.*failed/);
+    expect(sandcastleCalled).toBe(false);
+  });
+
+  it("throws when post-iteration gh pr list returns an empty array", async () => {
+    const { runner } = buildShellRunner([
+      {
+        match: (c) => c.cmd === "git" && c.args[0] === "push",
+        result: { exitCode: 0, stdout: "", stderr: "" },
+      },
+      {
+        match: (c) => c.cmd === "gh",
+        result: {
+          exitCode: 0,
+          stdout: "[]",
+          stderr: "",
+        },
+      },
+    ]);
+
+    const err = await captureError(
+      runPrSubmission({
+        ghRepo: baseGhRepo,
+        branch: "feature/per-32",
+        baseBranch: "master",
+        parentNumber: 7,
+        parentTitle: "PRD",
+        repoRoot: "/repo",
+        config: baseConfig,
+        sandboxEnv: {},
+        shellRunner: runner,
+        sandcastleRun: baseSandcastleRun,
+      })
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/no PR was found/);
+  });
+
+  it("wraps Sandcastle thrown errors with a tide-prefixed message", async () => {
+    const { runner } = buildShellRunner([
+      {
+        match: (c) => c.cmd === "git" && c.args[0] === "push",
+        result: { exitCode: 0, stdout: "", stderr: "" },
+      },
+    ]);
+
+    const sandcastleRun: SandcastleRun = () =>
+      Promise.reject(new Error("sandbox failed to start"));
+
+    const err = await captureError(
+      runPrSubmission({
+        ghRepo: baseGhRepo,
+        branch: "feature/per-32",
+        baseBranch: "master",
+        parentNumber: 7,
+        parentTitle: "PRD",
+        repoRoot: "/repo",
+        config: baseConfig,
+        sandboxEnv: {},
+        shellRunner: runner,
+        sandcastleRun,
+      })
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(
+      /PR submission iteration threw.*sandbox failed to start/
+    );
+  });
+});

--- a/src/pr-submission/index.test.ts
+++ b/src/pr-submission/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import {
+  countCommitsAhead,
   resolveBaseBranch,
   runPrSubmission,
   type ShellResult,
@@ -100,6 +101,52 @@ describe("resolveBaseBranch", () => {
     const err = await captureError(resolveBaseBranch("/tmp/repo", runner));
     expect(err).toBeInstanceOf(Error);
     expect((err as Error).message).toMatch(/git rev-parse.*failed/);
+  });
+});
+
+describe("countCommitsAhead", () => {
+  it("returns the parsed integer count on success", async () => {
+    const { runner, calls } = buildShellRunner([
+      {
+        match: (c) =>
+          c.cmd === "git" &&
+          c.args[0] === "rev-list" &&
+          c.args[1] === "--count",
+        result: { exitCode: 0, stdout: "5\n", stderr: "" },
+      },
+    ]);
+    const n = await countCommitsAhead("/tmp/repo", "main", "feature/x", runner);
+    expect(n).toBe(5);
+    expect(calls[0]?.args).toEqual(["rev-list", "--count", "main..feature/x"]);
+  });
+
+  it("returns 0 when the branch has no commits ahead of base", async () => {
+    const { runner } = buildShellRunner([
+      {
+        match: (c) => c.cmd === "git" && c.args[0] === "rev-list",
+        result: { exitCode: 0, stdout: "0\n", stderr: "" },
+      },
+    ]);
+    const n = await countCommitsAhead("/tmp/repo", "main", "feature/x", runner);
+    expect(n).toBe(0);
+  });
+
+  it("throws when git rev-list exits non-zero", async () => {
+    const { runner } = buildShellRunner([
+      {
+        match: (c) => c.cmd === "git" && c.args[0] === "rev-list",
+        result: {
+          exitCode: 128,
+          stdout: "",
+          stderr: "fatal: ambiguous argument",
+        },
+      },
+    ]);
+    const err = await captureError(
+      countCommitsAhead("/tmp/repo", "main", "feature/x", runner)
+    );
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toMatch(/git rev-list.*failed/);
   });
 });
 

--- a/src/pr-submission/index.test.ts
+++ b/src/pr-submission/index.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import {
+  buildPrPromptArgs,
   countCommitsAhead,
   resolveBaseBranch,
   runPrSubmission,
@@ -187,6 +188,10 @@ describe("runPrSubmission", () => {
       baseBranch: "master",
       parentNumber: 7,
       parentTitle: "PRD: example feature",
+      subIssues: [
+        { number: 8, title: "Foundation tracer" },
+        { number: 9, title: "Pre-flight clack confirm" },
+      ],
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
@@ -214,13 +219,31 @@ describe("runPrSubmission", () => {
     });
     expect(typeof receivedRunOptions.prompt).toBe("string");
     expect(receivedRunOptions.promptFile).toBeUndefined();
-    // Placeholder body must close the parent PRD.
+    // Body must close the parent PRD.
     expect(receivedRunOptions.prompt).toContain("Closes #7");
     // Branch and base must be substituted.
     expect(receivedRunOptions.prompt).toContain("feature/per-32");
     expect(receivedRunOptions.prompt).toContain("master");
     // Repo identifier is injected so the agent can pass --repo correctly.
     expect(receivedRunOptions.prompt).toContain("acme/widget");
+    // PRD URL is derived host-side from owner/repo + parent number and
+    // surfaced to the agent so it can link back from the body.
+    expect(receivedRunOptions.prompt).toContain(
+      "https://github.com/acme/widget/issues/7"
+    );
+    // The bundled rich template ships all six sections plus a Conventional
+    // Commits title rule.
+    expect(receivedRunOptions.prompt).toContain("🚩 The Problem");
+    expect(receivedRunOptions.prompt).toContain("💡 The Solution");
+    expect(receivedRunOptions.prompt).toContain("🏗 Interface Movements");
+    expect(receivedRunOptions.prompt).toContain("📦 Package Breakdowns");
+    expect(receivedRunOptions.prompt).toContain(
+      "🧹 Housekeeping & Secondary Changes"
+    );
+    expect(receivedRunOptions.prompt).toContain("Conventional Commits");
+    // Ordered sub-issue list shows up in the rendered prompt.
+    expect(receivedRunOptions.prompt).toContain("#8 Foundation tracer");
+    expect(receivedRunOptions.prompt).toContain("#9 Pre-flight clack confirm");
 
     // gh pr list ran with --head <branch>.
     const ghCall = calls.find((c) => c.cmd === "gh");
@@ -255,6 +278,7 @@ describe("runPrSubmission", () => {
         baseBranch: "master",
         parentNumber: 7,
         parentTitle: "PRD",
+        subIssues: [],
         repoRoot: "/repo",
         config: baseConfig,
         sandboxEnv: {},
@@ -290,6 +314,7 @@ describe("runPrSubmission", () => {
         baseBranch: "master",
         parentNumber: 7,
         parentTitle: "PRD",
+        subIssues: [],
         repoRoot: "/repo",
         config: baseConfig,
         sandboxEnv: {},
@@ -319,6 +344,7 @@ describe("runPrSubmission", () => {
         baseBranch: "master",
         parentNumber: 7,
         parentTitle: "PRD",
+        subIssues: [],
         repoRoot: "/repo",
         config: baseConfig,
         sandboxEnv: {},
@@ -330,5 +356,94 @@ describe("runPrSubmission", () => {
     expect((err as Error).message).toMatch(
       /PR submission iteration threw.*sandbox failed to start/
     );
+  });
+});
+
+describe("buildPrPromptArgs", () => {
+  const baseInput = {
+    parentNumber: 7,
+    parentTitle: "PRD: example feature",
+    parentUrl: "https://github.com/acme/widget/issues/7",
+    branch: "feature/per-32",
+    baseBranch: "master",
+    repoOwner: "acme",
+    repoName: "widget",
+  };
+
+  it("returns the full set of substitution keys", () => {
+    const args = buildPrPromptArgs({
+      ...baseInput,
+      subIssues: [{ number: 8, title: "Foundation tracer" }],
+    });
+    expect(Object.keys(args).sort()).toEqual(
+      [
+        "BASE_BRANCH",
+        "BRANCH",
+        "PARENT_ID",
+        "PARENT_TITLE",
+        "PARENT_URL",
+        "REPO_NAME",
+        "REPO_OWNER",
+        "SUB_ISSUES",
+      ].sort()
+    );
+    expect(args.PARENT_ID).toBe(7);
+    expect(args.PARENT_TITLE).toBe("PRD: example feature");
+    expect(args.PARENT_URL).toBe("https://github.com/acme/widget/issues/7");
+    expect(args.BRANCH).toBe("feature/per-32");
+    expect(args.BASE_BRANCH).toBe("master");
+    expect(args.REPO_OWNER).toBe("acme");
+    expect(args.REPO_NAME).toBe("widget");
+  });
+
+  it("renders zero sub-issues with a stable placeholder rather than an empty list", () => {
+    const args = buildPrPromptArgs({ ...baseInput, subIssues: [] });
+    expect(args.SUB_ISSUES).toBe("_(none)_");
+  });
+
+  it("renders one sub-issue as a single bullet line", () => {
+    const args = buildPrPromptArgs({
+      ...baseInput,
+      subIssues: [{ number: 42, title: "Wire up the runner" }],
+    });
+    expect(args.SUB_ISSUES).toBe("- #42 Wire up the runner");
+  });
+
+  it("renders many sub-issues in input order, one bullet per", () => {
+    const args = buildPrPromptArgs({
+      ...baseInput,
+      subIssues: [
+        { number: 8, title: "Foundation tracer" },
+        { number: 9, title: "Pre-flight clack confirm" },
+        { number: 10, title: "Rev-list zero-commits gate" },
+      ],
+    });
+    expect(args.SUB_ISSUES).toBe(
+      [
+        "- #8 Foundation tracer",
+        "- #9 Pre-flight clack confirm",
+        "- #10 Rev-list zero-commits gate",
+      ].join("\n")
+    );
+  });
+
+  it("collapses newlines in user-controlled titles to spaces (escaping)", () => {
+    const args = buildPrPromptArgs({
+      ...baseInput,
+      parentTitle: "PRD: line one\nline two",
+      subIssues: [{ number: 100, title: "Title with\r\nembedded\rnewlines" }],
+    });
+    expect(args.PARENT_TITLE).toBe("PRD: line one line two");
+    expect(args.SUB_ISSUES).toBe("- #100 Title with embedded newlines");
+  });
+
+  it("trims surrounding whitespace from titles", () => {
+    const args = buildPrPromptArgs({
+      ...baseInput,
+      parentTitle: "  Padded PRD  ",
+      subIssues: [{ number: 1, title: "  spaced  " }],
+    });
+    expect(args.PARENT_TITLE).toBe("Padded PRD");
+    expect(args.SUB_ISSUES).toBe("- #1 spaced");
   });
 });

--- a/src/pr-submission/index.ts
+++ b/src/pr-submission/index.ts
@@ -1,0 +1,302 @@
+// PR submission tail-step for `tide run`.
+//
+// After `runIssueQueue` succeeds, `tideRun` calls `runPrSubmission` to push
+// the feature branch host-side and fire a single Sandcastle iteration whose
+// only job is to open a PR via `gh pr create`. Success is verified host-side
+// via `gh pr list --head <branch>` (the iteration produces no commit, so the
+// runner's commit-based isFailedRun heuristic is not reused).
+//
+// This is the foundation tracer per issue #8 — a placeholder PR body with
+// just `Closes #<PRD>` is sufficient. The rich interface-emphasizing
+// template lands in a follow-up issue.
+//
+// Scope: only the "opened" path. The "updated" path (re-run with an existing
+// PR), the rev-list gate, the clack confirm, and the bundled rich template
+// are all out of scope for this slice.
+
+import { spawn } from "node:child_process";
+import { log } from "@clack/prompts";
+import { run as defaultSandcastleRun, claudeCode } from "@ai-hero/sandcastle";
+import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
+import type { TideConfig } from "../config-loader/index.ts";
+import type { GhRepo } from "../github/index.ts";
+
+export interface ShellResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type ShellRunner = (
+  cmd: string,
+  args: readonly string[],
+  cwd: string
+) => Promise<ShellResult>;
+
+export type SandcastleRun = typeof defaultSandcastleRun;
+
+export interface RunPrSubmissionOptions {
+  ghRepo: GhRepo;
+  branch: string;
+  baseBranch: string;
+  parentNumber: number;
+  parentTitle: string;
+  repoRoot: string;
+  config: TideConfig;
+  // Env map intended for the docker sandbox. Caller is responsible for
+  // stripping LINEAR_API_KEY (matches the queue runner's contract).
+  sandboxEnv: Record<string, string>;
+  // Test seams.
+  shellRunner?: ShellRunner;
+  sandcastleRun?: SandcastleRun;
+}
+
+export interface PrSubmissionResult {
+  url: string;
+  action: "opened";
+}
+
+async function defaultShellRunner(
+  cmd: string,
+  args: readonly string[],
+  cwd: string
+): Promise<ShellResult> {
+  return await new Promise<ShellResult>((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (err) => {
+      reject(err);
+    });
+    child.on("close", (code) => {
+      resolve({ exitCode: code ?? 0, stdout, stderr });
+    });
+  });
+}
+
+/**
+ * Capture the current branch via `git rev-parse --abbrev-ref HEAD`. Throws
+ * with a clear message on detached HEAD ("HEAD") so the caller can fail fast
+ * before any Sandcastle work runs.
+ */
+export async function resolveBaseBranch(
+  repoRoot: string,
+  shellRunner: ShellRunner = defaultShellRunner
+): Promise<string> {
+  const r = await shellRunner(
+    "git",
+    ["rev-parse", "--abbrev-ref", "HEAD"],
+    repoRoot
+  );
+  if (r.exitCode !== 0) {
+    const stderr = r.stderr.trim();
+    throw new Error(
+      `tide: \`git rev-parse --abbrev-ref HEAD\` failed (exit ${String(r.exitCode)})${stderr === "" ? "" : `: ${stderr}`}`
+    );
+  }
+  const branch = r.stdout.trim();
+  if (branch === "" || branch === "HEAD") {
+    throw new Error(
+      "tide: detached HEAD detected. Check out a branch before running `tide run`."
+    );
+  }
+  return branch;
+}
+
+const PR_PROMPT_TEMPLATE = `You are submitting a pull request for parent issue #{{PARENT_ID}}: {{PARENT_TITLE}}.
+
+The current working branch is \`{{BRANCH}}\` (already pushed to origin). Open a pull request against the base branch \`{{BASE_BRANCH}}\` for the repository \`{{REPO_OWNER}}/{{REPO_NAME}}\`.
+
+Use the following exact PR body (it includes the \`Closes #{{PARENT_ID}}\` reference so merging the PR auto-closes the parent issue):
+
+----- BEGIN PR BODY -----
+{{PR_BODY}}
+----- END PR BODY -----
+
+Suggested PR title (you may refine based on the diff, but keep it concise and descriptive):
+  {{PR_TITLE}}
+
+Run \`gh pr create\` against the right base. A safe invocation:
+
+  gh pr create \\
+    --repo {{REPO_OWNER}}/{{REPO_NAME}} \\
+    --base {{BASE_BRANCH}} \\
+    --head {{BRANCH}} \\
+    --title "<your title here>" \\
+    --body-file <(cat <<'EOF'
+{{PR_BODY}}
+EOF
+)
+
+When the PR has been opened successfully, emit <promise>COMPLETE</promise> and exit. Do not edit any files in the working tree.
+`;
+
+function buildPrompt(opts: {
+  parentNumber: number;
+  parentTitle: string;
+  branch: string;
+  baseBranch: string;
+  ghRepo: GhRepo;
+}): string {
+  const placeholderTitle = `tide: ${opts.parentTitle}`;
+  const placeholderBody = `Closes #${String(opts.parentNumber)}\n\nAutomated submission for parent issue #${String(opts.parentNumber)}: ${opts.parentTitle}.`;
+  return PR_PROMPT_TEMPLATE.replaceAll(
+    "{{PARENT_ID}}",
+    String(opts.parentNumber)
+  )
+    .replaceAll("{{PARENT_TITLE}}", opts.parentTitle)
+    .replaceAll("{{BRANCH}}", opts.branch)
+    .replaceAll("{{BASE_BRANCH}}", opts.baseBranch)
+    .replaceAll("{{REPO_OWNER}}", opts.ghRepo.owner)
+    .replaceAll("{{REPO_NAME}}", opts.ghRepo.repo)
+    .replaceAll("{{PR_TITLE}}", placeholderTitle)
+    .replaceAll("{{PR_BODY}}", placeholderBody);
+}
+
+interface PrListItem {
+  url: string;
+  number: number;
+}
+
+function parsePrList(stdout: string): PrListItem[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new Error(
+      `tide: \`gh pr list\` produced non-JSON output: ${stdout.trim()}`
+    );
+  }
+  if (!Array.isArray(parsed)) {
+    throw new Error(`tide: \`gh pr list\` returned a non-array payload.`);
+  }
+  const out: PrListItem[] = [];
+  for (const entry of parsed) {
+    if (entry === null || typeof entry !== "object") continue;
+    const obj = entry as Record<string, unknown>;
+    const url = obj.url;
+    const number = obj.number;
+    if (typeof url === "string" && typeof number === "number") {
+      out.push({ url, number });
+    }
+  }
+  return out;
+}
+
+/**
+ * Push the branch to origin, fire a single Sandcastle iteration whose only
+ * job is to open the PR via `gh pr create`, and verify the result by listing
+ * PRs for the branch on the host. Throws on push failure, iteration error,
+ * or empty post-iteration PR list.
+ */
+export async function runPrSubmission(
+  options: RunPrSubmissionOptions
+): Promise<PrSubmissionResult> {
+  const {
+    ghRepo,
+    branch,
+    baseBranch,
+    parentNumber,
+    parentTitle,
+    repoRoot,
+    config,
+    sandboxEnv,
+    shellRunner = defaultShellRunner,
+    sandcastleRun = defaultSandcastleRun,
+  } = options;
+
+  // Step 1: push the branch to origin host-side. Surfacing push errors here
+  // (rather than wrapping them inside an LLM iteration failure) keeps the
+  // failure mode legible.
+  log.info(`Pushing ${branch} to origin`);
+  const pushResult = await shellRunner(
+    "git",
+    ["push", "-u", "origin", branch],
+    repoRoot
+  );
+  if (pushResult.exitCode !== 0) {
+    const stderr = pushResult.stderr.trim();
+    throw new Error(
+      `tide: \`git push -u origin ${branch}\` failed (exit ${String(pushResult.exitCode)})${stderr === "" ? "" : `: ${stderr}`}`
+    );
+  }
+
+  // Step 2: fire the Sandcastle iteration with the bundled placeholder
+  // prompt. Inline `prompt` (not `promptFile`) — the template ships in tide
+  // source and is not user-editable.
+  const prompt = buildPrompt({
+    parentNumber,
+    parentTitle,
+    branch,
+    baseBranch,
+    ghRepo,
+  });
+
+  const sandbox = docker({
+    mounts: config.sandbox.mounts,
+    env: sandboxEnv,
+  });
+
+  try {
+    // The iteration produces no commit by design — its output is observable
+    // via `gh pr list` below, not via the RunResult, so we discard the result.
+    await sandcastleRun({
+      name: "tide-pr",
+      cwd: repoRoot,
+      sandbox,
+      agent: claudeCode("claude-opus-4-7"),
+      prompt,
+      maxIterations: 1,
+      branchStrategy: { type: "branch", branch },
+      logging: { type: "stdout" },
+      hooks: {
+        sandbox: {
+          onSandboxReady: config.hooks.onSandboxReady,
+        },
+      },
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new Error(`tide: PR submission iteration threw: ${msg}`, {
+      cause: err,
+    });
+  }
+
+  // Step 3: verify host-side that a PR now exists for the branch.
+  const listResult = await shellRunner(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--repo",
+      `${ghRepo.owner}/${ghRepo.repo}`,
+      "--head",
+      branch,
+      "--json",
+      "number,url",
+    ],
+    repoRoot
+  );
+  if (listResult.exitCode !== 0) {
+    const stderr = listResult.stderr.trim();
+    throw new Error(
+      `tide: \`gh pr list --head ${branch}\` failed (exit ${String(listResult.exitCode)})${stderr === "" ? "" : `: ${stderr}`}`
+    );
+  }
+
+  const prs = parsePrList(listResult.stdout);
+  const first = prs[0];
+  if (first === undefined) {
+    throw new Error(
+      `tide: PR submission iteration completed but no PR was found on origin for branch ${branch}. Inspect the iteration log and re-run.`
+    );
+  }
+
+  return { url: first.url, action: "opened" };
+}

--- a/src/pr-submission/index.ts
+++ b/src/pr-submission/index.ts
@@ -81,6 +81,36 @@ async function defaultShellRunner(
 }
 
 /**
+ * Count how many commits `branch` is ahead of `baseBranch` via
+ * `git rev-list --count <baseBranch>..<branch>`. Used host-side as the gate
+ * before invoking the PR-submission iteration: a zero-commits branch can't
+ * produce a meaningful PR.
+ */
+export async function countCommitsAhead(
+  repoRoot: string,
+  baseBranch: string,
+  branch: string,
+  shellRunner: ShellRunner = defaultShellRunner
+): Promise<number> {
+  const range = `${baseBranch}..${branch}`;
+  const r = await shellRunner("git", ["rev-list", "--count", range], repoRoot);
+  if (r.exitCode !== 0) {
+    const stderr = r.stderr.trim();
+    throw new Error(
+      `tide: \`git rev-list --count ${range}\` failed (exit ${String(r.exitCode)})${stderr === "" ? "" : `: ${stderr}`}`
+    );
+  }
+  const trimmed = r.stdout.trim();
+  const n = Number.parseInt(trimmed, 10);
+  if (!Number.isFinite(n) || n < 0 || String(n) !== trimmed) {
+    throw new Error(
+      `tide: \`git rev-list --count ${range}\` returned non-numeric output: ${trimmed}`
+    );
+  }
+  return n;
+}
+
+/**
  * Capture the current branch via `git rev-parse --abbrev-ref HEAD`. Throws
  * with a clear message on detached HEAD ("HEAD") so the caller can fail fast
  * before any Sandcastle work runs.

--- a/src/pr-submission/index.ts
+++ b/src/pr-submission/index.ts
@@ -6,13 +6,14 @@
 // via `gh pr list --head <branch>` (the iteration produces no commit, so the
 // runner's commit-based isFailedRun heuristic is not reused).
 //
-// This is the foundation tracer per issue #8 — a placeholder PR body with
-// just `Closes #<PRD>` is sufficient. The rich interface-emphasizing
-// template lands in a follow-up issue.
+// The bundled prompt template is interface-emphasizing (Ousterhout: the
+// change callers see is the change that matters) and ships as a TypeScript
+// string constant — not user-editable like `.tide/prompt.md`. Substitution
+// is driven by `buildPrPromptArgs`, a pure function that returns the
+// `{{KEY}}` map applied to the template.
 //
-// Scope: only the "opened" path. The "updated" path (re-run with an existing
-// PR), the rev-list gate, the clack confirm, and the bundled rich template
-// are all out of scope for this slice.
+// Scope: only the "opened" path. The "updated" path (re-run with an
+// existing PR) is out of scope for this slice.
 
 import { spawn } from "node:child_process";
 import { log } from "@clack/prompts";
@@ -35,12 +36,20 @@ export type ShellRunner = (
 
 export type SandcastleRun = typeof defaultSandcastleRun;
 
+export interface SubIssueRef {
+  number: number;
+  title: string;
+}
+
 export interface RunPrSubmissionOptions {
   ghRepo: GhRepo;
   branch: string;
   baseBranch: string;
   parentNumber: number;
   parentTitle: string;
+  // Topo-ordered sub-issues addressed by this PR. Surfaces in the rendered
+  // prompt's Context section so the agent can scope its diff summary.
+  subIssues: SubIssueRef[];
   repoRoot: string;
   config: TideConfig;
   // Env map intended for the docker sandbox. Caller is responsible for
@@ -139,54 +148,163 @@ export async function resolveBaseBranch(
   return branch;
 }
 
+// Bundled, interface-emphasizing PR template. Renders six body sections
+// (🚩 The Problem · 💡 The Solution · 🏗 Interface Movements · 📦 Package
+// Breakdowns · 🧹 Housekeeping & Secondary Changes · `Closes #<PRD>`) plus a
+// Conventional Commits title rule. The agent classifies changed identifiers
+// as public/private using the rules in the `Interface Movements` section
+// and populates the table only with public surface that actually moved.
+//
+// Single-phase: no `<sub>Files-changed:</sub>` anchor links — those would
+// require a two-phase create-then-edit flow to inject post-creation URLs.
 const PR_PROMPT_TEMPLATE = `You are submitting a pull request for parent issue #{{PARENT_ID}}: {{PARENT_TITLE}}.
 
 The current working branch is \`{{BRANCH}}\` (already pushed to origin). Open a pull request against the base branch \`{{BASE_BRANCH}}\` for the repository \`{{REPO_OWNER}}/{{REPO_NAME}}\`.
 
-Use the following exact PR body (it includes the \`Closes #{{PARENT_ID}}\` reference so merging the PR auto-closes the parent issue):
+# Context
 
------ BEGIN PR BODY -----
-{{PR_BODY}}
------ END PR BODY -----
+- Parent PRD: {{PARENT_URL}}
+- Sub-issues addressed (in order):
+{{SUB_ISSUES}}
 
-Suggested PR title (you may refine based on the diff, but keep it concise and descriptive):
-  {{PR_TITLE}}
+# Title
+
+Use Conventional Commits: \`<type>(<scope>): <subject>\`.
+
+- \`<type>\` is one of \`feat\`, \`fix\`, \`chore\`, \`docs\`, \`refactor\`, \`test\`, \`build\`, \`ci\`, \`perf\`, \`style\`. Pick the type that best matches the headline change in the diff.
+- \`<scope>\` is the package or area touched. Optional — omit it for multi-package PRDs that span scopes.
+- \`<subject>\` is a concise, imperative-mood summary derived from the diff.
+
+Examples: \`feat(runner): add per-iteration timeout\` or \`refactor: extract pr-submission module\`.
+
+# Body — sections in this exact order
+
+Render the body as the sections below, in order, with the exact emoji headers shown. End with the \`Closes #{{PARENT_ID}}\` line.
+
+## 🚩 The Problem
+
+2–4 bullets. What was wrong, missing, or painful before this change. Frame from the user's or caller's point of view, not the implementer's.
+
+## 💡 The Solution
+
+2–4 bullets. What changed at the conceptual level. Where it applies, name the operation explicitly:
+
+- **Deepen** — add functionality behind an existing interface.
+- **Widen** — broaden an interface to handle a new shape of input/output.
+- **Extract** — pull a chunk into a new module with its own boundary.
+
+## 🏗 Interface Movements
+
+A markdown table with columns: \`Symbol | Old location | New location | Notes\`.
+
+Populate the table only with **public** surface that actually moved. Public means anything a caller outside this PR's diff could observe:
+
+- TypeScript / JavaScript: any symbol exported via \`export\` from a package or a public module entry point. Internal helpers (un-exported, or under an \`_internal\` re-export) are private.
+- HTTP / RPC: any route, method, request/response field, or status code reachable from outside the service.
+- CLI: any command, sub-command, flag, or environment variable.
+- Config: any key in user-facing config files (\`.tide/config.ts\`, \`package.json\`'s public fields, etc.).
+
+If nothing public moved, write \`_(no public surface moved)_\` instead of an empty table.
+
+## 📦 Package Breakdowns
+
+For each package or top-level directory that changed, add a \`<details>\` block:
+
+    <details>
+    <summary><code>src/&lt;package&gt;/</code> — one-line summary</summary>
+
+    - bullet describing the change in this package
+    - another bullet
+
+    </details>
+
+Group by directory, not by file. Order packages so a reviewer can walk through them naturally — entry points first, then leaf modules, then tests.
+
+## 🧹 Housekeeping & Secondary Changes
+
+Anything that is not part of the headline change but ships in the same PR: dependency bumps, formatting passes, comment cleanups, test refactors, docs touch-ups. One bullet per item. If there is none, write \`_(none)_\`.
+
+## Closes
+
+End the body with a single line: \`Closes #{{PARENT_ID}}\`. This auto-closes the parent PRD when the PR merges. Do not include \`<sub>Files-changed:</sub>\` anchor links — the bundled template uses a single-phase \`gh pr create\` and does not inject post-creation URLs.
+
+# How to submit
 
 Run \`gh pr create\` against the right base. A safe invocation:
 
-  gh pr create \\
-    --repo {{REPO_OWNER}}/{{REPO_NAME}} \\
-    --base {{BASE_BRANCH}} \\
-    --head {{BRANCH}} \\
-    --title "<your title here>" \\
-    --body-file <(cat <<'EOF'
-{{PR_BODY}}
-EOF
-)
+    gh pr create \\
+      --repo {{REPO_OWNER}}/{{REPO_NAME}} \\
+      --base {{BASE_BRANCH}} \\
+      --head {{BRANCH}} \\
+      --title "<your title here>" \\
+      --body-file <(cat <<'PR_BODY_EOF'
+    <your fully-rendered body here, including the Closes line>
+    PR_BODY_EOF
+    )
 
 When the PR has been opened successfully, emit <promise>COMPLETE</promise> and exit. Do not edit any files in the working tree.
 `;
 
-function buildPrompt(opts: {
+export interface BuildPrPromptArgsInput {
   parentNumber: number;
   parentTitle: string;
+  parentUrl: string;
   branch: string;
   baseBranch: string;
-  ghRepo: GhRepo;
-}): string {
-  const placeholderTitle = `tide: ${opts.parentTitle}`;
-  const placeholderBody = `Closes #${String(opts.parentNumber)}\n\nAutomated submission for parent issue #${String(opts.parentNumber)}: ${opts.parentTitle}.`;
-  return PR_PROMPT_TEMPLATE.replaceAll(
-    "{{PARENT_ID}}",
-    String(opts.parentNumber)
-  )
-    .replaceAll("{{PARENT_TITLE}}", opts.parentTitle)
-    .replaceAll("{{BRANCH}}", opts.branch)
-    .replaceAll("{{BASE_BRANCH}}", opts.baseBranch)
-    .replaceAll("{{REPO_OWNER}}", opts.ghRepo.owner)
-    .replaceAll("{{REPO_NAME}}", opts.ghRepo.repo)
-    .replaceAll("{{PR_TITLE}}", placeholderTitle)
-    .replaceAll("{{PR_BODY}}", placeholderBody);
+  repoOwner: string;
+  repoName: string;
+  subIssues: SubIssueRef[];
+}
+
+export type PrPromptArgsRecord = Record<string, string | number>;
+
+const SUB_ISSUES_NONE = "_(none)_";
+
+// Collapse internal whitespace runs (including embedded newlines and
+// carriage returns) to a single space, then trim. Keeps user-controlled
+// titles from breaking the markdown structure of the rendered prompt.
+function sanitizeInline(value: string): string {
+  return value.replace(/\s+/g, " ").trim();
+}
+
+function renderSubIssues(subs: readonly SubIssueRef[]): string {
+  if (subs.length === 0) return SUB_ISSUES_NONE;
+  return subs
+    .map((s) => `- #${String(s.number)} ${sanitizeInline(s.title)}`)
+    .join("\n");
+}
+
+/**
+ * Pure: build the `{{KEY}}` substitution map for the bundled PR prompt
+ * template. Returns numbers as numbers and strings as strings so the
+ * record matches the shape Sandcastle's `promptArgs` accepts. Titles are
+ * inlined (newlines collapsed, trimmed) to keep template substitution from
+ * breaking the surrounding markdown.
+ */
+export function buildPrPromptArgs(
+  input: BuildPrPromptArgsInput
+): PrPromptArgsRecord {
+  return {
+    PARENT_ID: input.parentNumber,
+    PARENT_TITLE: sanitizeInline(input.parentTitle),
+    PARENT_URL: input.parentUrl,
+    BRANCH: input.branch,
+    BASE_BRANCH: input.baseBranch,
+    REPO_OWNER: input.repoOwner,
+    REPO_NAME: input.repoName,
+    SUB_ISSUES: renderSubIssues(input.subIssues),
+  };
+}
+
+function applyPromptTemplate(
+  template: string,
+  args: PrPromptArgsRecord
+): string {
+  let out = template;
+  for (const [key, value] of Object.entries(args)) {
+    out = out.replaceAll(`{{${key}}}`, String(value));
+  }
+  return out;
 }
 
 interface PrListItem {
@@ -234,6 +352,7 @@ export async function runPrSubmission(
     baseBranch,
     parentNumber,
     parentTitle,
+    subIssues,
     repoRoot,
     config,
     sandboxEnv,
@@ -257,16 +376,20 @@ export async function runPrSubmission(
     );
   }
 
-  // Step 2: fire the Sandcastle iteration with the bundled placeholder
-  // prompt. Inline `prompt` (not `promptFile`) — the template ships in tide
-  // source and is not user-editable.
-  const prompt = buildPrompt({
+  // Step 2: fire the Sandcastle iteration with the bundled, interface-
+  // emphasizing prompt. Inline `prompt` (not `promptFile`) — the template
+  // ships in tide source and is not user-editable.
+  const promptArgs = buildPrPromptArgs({
     parentNumber,
     parentTitle,
+    parentUrl: `https://github.com/${ghRepo.owner}/${ghRepo.repo}/issues/${String(parentNumber)}`,
     branch,
     baseBranch,
-    ghRepo,
+    repoOwner: ghRepo.owner,
+    repoName: ghRepo.repo,
+    subIssues,
   });
+  const prompt = applyPromptTemplate(PR_PROMPT_TEMPLATE, promptArgs);
 
   const sandbox = docker({
     mounts: config.sandbox.mounts,


### PR DESCRIPTION
## 🚩 The Problem

* After `tide run` completes a PRD's queue, the user is left holding a feature branch with no PR — context-switch to a browser to draft and open one by hand.
* Hand-drafted PR bodies for multi-issue runs are low-signal; reviewers reconstruct intent from commit messages.
* Easy to forget the `Closes #<PRD>` reference, so merging the PR doesn't auto-close the parent PRD.
* No fail-fast for detached HEAD — a queue could complete before discovering the PR step has no branch to push.

## 💡 The Solution

* **Extract** a new `src/pr-submission/` module — deep: one orchestrator entry + one pure helper exported, the bundled template and shell-outs internal.
* On queue success, host pushes the branch and fires one Sandcastle iteration whose only job is `gh pr create` with an interface-emphasizing body (Ousterhout: callers see the public surface).
* Pre-flight clack confirm ("Create a PR at the end?") + post-queue rev-list gate skip the step cleanly when the user opts out or there's nothing to submit.
* Base branch captured at the top of `tideRun` from `git rev-parse --abbrev-ref HEAD` — detached HEAD fails fast before any work runs.

## 🏗 Architecture & Public Interface Changes

### 🗺 Interface Movements

| Interface / Symbol | Old Location / Status | New Location / Status | Notes |
| :--- | :--- | :--- | :--- |
| `runPrSubmission` | 🆕 new | `src/pr-submission` | Orchestrator entry point — push, iterate, verify |
| `buildPrPromptArgs` | 🆕 new | `src/pr-submission` | Pure `{{KEY}}` substitution-map builder |
| `countCommitsAhead` | 🆕 new | `src/pr-submission` | Host-side rev-list gate |
| `resolveBaseBranch` | 🆕 new | `src/pr-submission` | Fail-fast `git rev-parse --abbrev-ref HEAD` capture |
| `RunPrSubmissionOptions`, `PrSubmissionResult`, `SubIssueRef`, `ShellRunner`, `BuildPrPromptArgsInput`, `PrPromptArgsRecord` | 🆕 new | `src/pr-submission` | Public types |
| `runPrTailStep` | 🆕 new | `src/cli/run` | Post-queue decision helper (opt-out / skip-empty / open / fail) |
| `RunOptions.baseBranchShellRunner`, `RunOptions.runPrSubmission` | 🆕 new fields | `src/cli/run` | Test seams |
| `tide run` flow | queue → outro | queue → pre-flight confirm → push → PR iteration → verify → outro | New tail step |

### 📦 Package Breakdowns

#### 1. `src/pr-submission/` (new module)

*Owns the entire PR-submission flow. Public surface is one orchestrator (`runPrSubmission`) plus a pure prompt-arg builder; the bundled prompt template, `git push`/`gh pr list` shell-outs, sandbox wiring, and post-iteration verification are internal.*

<details>
<summary>🔍 View Interface Changes</summary>

```diff
+ export interface SubIssueRef { number: number; title: string }

+ export interface ShellResult { exitCode: number; stdout: string; stderr: string }
+ export type ShellRunner = (cmd: string, args: readonly string[], cwd: string) => Promise<ShellResult>

+ export interface RunPrSubmissionOptions { ghRepo, branch, baseBranch, parentNumber, parentTitle, subIssues, repoRoot, config, sandboxEnv, ... }
+ export interface PrSubmissionResult { url: string; action: "opened" }

+ export async function runPrSubmission(options: RunPrSubmissionOptions): Promise<PrSubmissionResult>

+ export async function resolveBaseBranch(repoRoot: string, shellRunner?: ShellRunner): Promise<string>
+ export async function countCommitsAhead(repoRoot: string, baseBranch: string, branch: string, shellRunner?: ShellRunner): Promise<number>

+ export interface BuildPrPromptArgsInput { parentNumber, parentTitle, parentUrl, branch, baseBranch, repoOwner, repoName, subIssues }
+ export type PrPromptArgsRecord = Record<string, string | number>
+ export function buildPrPromptArgs(input: BuildPrPromptArgsInput): PrPromptArgsRecord
```

</details>

<sub>**Files changed:** [`index.ts`](https://github.com/m1yon/tide/pull/18/files#diff-4a5ee0aad6d6f904ffcebf18e4fb75f9a27ac739ebf647ec25cae9a64d3d300a), [`index.test.ts`](https://github.com/m1yon/tide/pull/18/files#diff-cdcccb855ec5e4e0eb96d20d06271609eec6ce8ec1c10ced14567b55b95de33f)</sub>

---

#### 2. `src/cli/run.ts`

*Captures the base branch up front, adds one clack confirm for PR creation, and delegates the post-queue decision to `runPrTailStep`. The success path now branches on opt-out / empty-branch / open / fail and renders a uniform outro for each.*

<details>
<summary>🔍 View Interface Changes</summary>

```diff
  export interface RunOptions {
    repoRoot?: string
    stdout?: (chunk: string) => void
    stderr?: (chunk: string) => void
+   baseBranchShellRunner?: ShellRunner
+   runPrSubmission?: (options: RunPrSubmissionOptions) => Promise<PrSubmissionResult>
  }

+ export type PrTailOutcome =
+   | { kind: "opted-out" }
+   | { kind: "skipped-empty" }
+   | { kind: "opened"; url: string }
+   | { kind: "failed"; message: string }

+ export interface PrTailStepResult { outcome: PrTailOutcome; outroMessage: string; exitCode: 0 | 1 }
+ export interface RunPrTailStepOptions { prCreationConfirmed, ghRepo, branch, baseBranch, parentNumber, parentTitle, subIssues, repoRoot, config, sandboxEnv, completedCount, ... }
+ export async function runPrTailStep(opts: RunPrTailStepOptions): Promise<PrTailStepResult>
```

</details>

<sub>**Files changed:** [`run.ts`](https://github.com/m1yon/tide/pull/18/files#diff-dfa9baf011a9c38263c91af5d92745dd686bcc12a41d4974257c98da689589df), [`run.test.ts`](https://github.com/m1yon/tide/pull/18/files#diff-8ddf6e9a622d2440af27fb802251e7b9b9c1468385aee7f8a8c292ba90a7192d)</sub>

## 🧹 Housekeeping & Secondary Changes

* New `src/pr-submission/index.test.ts` (449 lines) covers `buildPrPromptArgs` substitution and the orchestrator's push → iterate → verify open path with `shellRunner` / `sandcastleRun` test seams.
* New `src/cli/run.test.ts` (231 lines) covers `runPrTailStep`'s decision matrix: opt-out, rev-list zero, open success, submission failure.
* Header comment in `src/cli/run.ts` updated: now documents base-branch capture (step 1) and the PR-submission step 7.
* "Updated" path (re-run with an existing PR via `gh pr edit`) is intentionally not in this PR — the orchestrator's `action` discriminant is fixed at `"opened"` for now and will widen when that slice lands.

Closes #7