### PR TITLE
feat(cli): auto-build sandbox image at the start of tide run

### DIFF
--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -1,0 +1,185 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { tideRun } from "./run.ts";
+import type { BuildOptions } from "./build.ts";
+import type { GhRepo, TreeNode } from "../github/index.ts";
+import type { GhIdentity } from "../gh-identity/index.ts";
+
+interface CallLog {
+  events: string[];
+}
+
+interface BuildStub {
+  exitCode: number;
+  calls: BuildOptions[];
+}
+
+function makeBuild(stub: BuildStub, log: CallLog) {
+  return (opts: BuildOptions): Promise<number> => {
+    stub.calls.push(opts);
+    log.events.push("build");
+    return Promise.resolve(stub.exitCode);
+  };
+}
+
+function makeGhIdentity(log: CallLog) {
+  return (): Promise<GhIdentity> => {
+    log.events.push("getGhIdentity");
+    return Promise.resolve({ owner: "m1yon", repo: "tide" });
+  };
+}
+
+interface FetchStub {
+  tree: TreeNode[];
+  calls: GhRepo[];
+}
+
+function makeFetchTriageTree(stub: FetchStub, log: CallLog) {
+  return (ghRepo: GhRepo): Promise<TreeNode[]> => {
+    stub.calls.push(ghRepo);
+    log.events.push("fetchTriageTree");
+    return Promise.resolve(stub.tree);
+  };
+}
+
+describe("tide run — build step", () => {
+  let workDir: string;
+  let repoRoot: string;
+  let tideDir: string;
+  let stdoutChunks: string[];
+  let stderrChunks: string[];
+  const captureStdout = (s: string): void => {
+    stdoutChunks.push(s);
+  };
+  const captureStderr = (s: string): void => {
+    stderrChunks.push(s);
+  };
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "tide-run-"));
+    repoRoot = join(workDir, "repo");
+    tideDir = join(repoRoot, ".tide");
+    mkdirSync(join(repoRoot, ".git"), { recursive: true });
+    mkdirSync(tideDir, { recursive: true });
+    writeFileSync(
+      join(tideDir, "config.ts"),
+      `export default { linear: { team: "ENG" } };\n`
+    );
+    writeFileSync(
+      join(tideDir, ".env"),
+      "LINEAR_API_KEY=lk\nANTHROPIC_API_KEY=ak\n"
+    );
+    writeFileSync(join(tideDir, "Dockerfile"), "FROM scratch\n");
+    stdoutChunks = [];
+    stderrChunks = [];
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("invokes build before fetching the triage tree", async () => {
+    const log: CallLog = { events: [] };
+    const buildStub: BuildStub = { exitCode: 0, calls: [] };
+    const fetchStub: FetchStub = { tree: [], calls: [] };
+
+    const code = await tideRun({
+      repoRoot,
+      stdout: captureStdout,
+      stderr: captureStderr,
+      build: makeBuild(buildStub, log),
+      getGhIdentity: makeGhIdentity(log),
+      fetchTriageTree: makeFetchTriageTree(fetchStub, log),
+    });
+
+    expect(code).toBe(0);
+    expect(buildStub.calls).toHaveLength(1);
+    expect(fetchStub.calls).toHaveLength(1);
+    const buildIdx = log.events.indexOf("build");
+    const fetchIdx = log.events.indexOf("fetchTriageTree");
+    expect(buildIdx).toBeGreaterThanOrEqual(0);
+    expect(fetchIdx).toBeGreaterThan(buildIdx);
+  });
+
+  test("build receives the resolved repoRoot and the same stdout/stderr sinks", async () => {
+    const log: CallLog = { events: [] };
+    const buildStub: BuildStub = { exitCode: 0, calls: [] };
+    const fetchStub: FetchStub = { tree: [], calls: [] };
+
+    await tideRun({
+      repoRoot,
+      stdout: captureStdout,
+      stderr: captureStderr,
+      build: makeBuild(buildStub, log),
+      getGhIdentity: makeGhIdentity(log),
+      fetchTriageTree: makeFetchTriageTree(fetchStub, log),
+    });
+
+    const call = buildStub.calls[0];
+    if (call === undefined) throw new Error("missing build call");
+    expect(call.repoRoot).toBe(repoRoot);
+    expect(call.stdout).toBe(captureStdout);
+    expect(call.stderr).toBe(captureStderr);
+  });
+
+  test("build failure short-circuits with the build's exit code; triage tree fetch never runs", async () => {
+    const log: CallLog = { events: [] };
+    const buildStub: BuildStub = { exitCode: 2, calls: [] };
+    const fetchStub: FetchStub = { tree: [], calls: [] };
+
+    const code = await tideRun({
+      repoRoot,
+      stdout: captureStdout,
+      stderr: captureStderr,
+      build: makeBuild(buildStub, log),
+      getGhIdentity: makeGhIdentity(log),
+      fetchTriageTree: makeFetchTriageTree(fetchStub, log),
+    });
+
+    expect(code).toBe(2);
+    expect(buildStub.calls).toHaveLength(1);
+    expect(fetchStub.calls).toHaveLength(0);
+  });
+
+  test("build success allows the existing flow to proceed", async () => {
+    const log: CallLog = { events: [] };
+    const buildStub: BuildStub = { exitCode: 0, calls: [] };
+    const fetchStub: FetchStub = { tree: [], calls: [] };
+
+    const code = await tideRun({
+      repoRoot,
+      stdout: captureStdout,
+      stderr: captureStderr,
+      build: makeBuild(buildStub, log),
+      getGhIdentity: makeGhIdentity(log),
+      fetchTriageTree: makeFetchTriageTree(fetchStub, log),
+    });
+
+    // Empty triage tree → "Nothing to triage" branch returns 0.
+    expect(code).toBe(0);
+    expect(buildStub.calls).toHaveLength(1);
+    expect(fetchStub.calls).toHaveLength(1);
+  });
+
+  test("build runs after gh-identity is resolved", async () => {
+    const log: CallLog = { events: [] };
+    const buildStub: BuildStub = { exitCode: 0, calls: [] };
+    const fetchStub: FetchStub = { tree: [], calls: [] };
+
+    await tideRun({
+      repoRoot,
+      stdout: captureStdout,
+      stderr: captureStderr,
+      build: makeBuild(buildStub, log),
+      getGhIdentity: makeGhIdentity(log),
+      fetchTriageTree: makeFetchTriageTree(fetchStub, log),
+    });
+
+    const ghIdx = log.events.indexOf("getGhIdentity");
+    const buildIdx = log.events.indexOf("build");
+    expect(ghIdx).toBeGreaterThanOrEqual(0);
+    expect(buildIdx).toBeGreaterThan(ghIdx);
+  });
+});

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -22,16 +22,22 @@ import {
   isCancel,
   cancel,
 } from "@clack/prompts";
+import { build as defaultBuild, type BuildOptions } from "./build.ts";
 import { loadConfig, type TideConfig } from "../config-loader/index.ts";
 import { loadEnv } from "../env-loader/index.ts";
 import { type DepNode, topoSort } from "../dep-graph/index.ts";
 import {
   fetchIssueStates,
   fetchSubtreeStates,
-  fetchTriageTree,
+  fetchTriageTree as defaultFetchTriageTree,
   type GhRepo,
+  type TreeNode,
 } from "../github/index.ts";
-import { getGhIdentity } from "../gh-identity/index.ts";
+import {
+  getGhIdentity as defaultGetGhIdentity,
+  type GetGhIdentityOptions,
+  type GhIdentity,
+} from "../gh-identity/index.ts";
 import type { ParentForLinear } from "../linear/index.ts";
 import { discoverRepoRoot } from "../repo-discovery/index.ts";
 import { runIssueQueue } from "../runner/index.ts";
@@ -42,6 +48,12 @@ export interface RunOptions {
   repoRoot?: string;
   stdout?: (chunk: string) => void;
   stderr?: (chunk: string) => void;
+  /** Build step. Tests stub this to avoid spawning docker. */
+  build?: (options: BuildOptions) => Promise<number>;
+  /** gh-identity resolver. Tests stub this to avoid spawning `gh`. */
+  getGhIdentity?: (options: GetGhIdentityOptions) => Promise<GhIdentity>;
+  /** Triage-tree fetcher. Tests stub this to avoid hitting GitHub. */
+  fetchTriageTree?: (ghRepo: GhRepo) => Promise<TreeNode[]>;
 }
 
 /**
@@ -76,6 +88,9 @@ function ensureSandcastleSymlink(repoRoot: string): void {
 export async function tideRun(options: RunOptions = {}): Promise<number> {
   const stdout = options.stdout ?? ((s: string) => process.stdout.write(s));
   const stderr = options.stderr ?? ((s: string) => process.stderr.write(s));
+  const build = options.build ?? defaultBuild;
+  const getGhIdentity = options.getGhIdentity ?? defaultGetGhIdentity;
+  const fetchTriageTree = options.fetchTriageTree ?? defaultFetchTriageTree;
 
   let repoRoot: string;
   try {
@@ -131,6 +146,15 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
   // is `.tide/`. Bridge with a symlink so the SDK paths land in the right
   // place. (See PRD: "Sandcastle worktrees and logs land at .tide/...".)
   ensureSandcastleSymlink(repoRoot);
+
+  // Ensure the sandbox image is up to date before any clack UI is started —
+  // streamed docker output otherwise interferes with clack rendering. Docker's
+  // layer cache makes the no-work case cheap and picks up Dockerfile changes
+  // automatically.
+  const buildExit = await build({ repoRoot, stdout, stderr });
+  if (buildExit !== 0) {
+    return buildExit;
+  }
 
   intro("tide run");
 


### PR DESCRIPTION
## 🚩 The Problem

* `tide run` against a fresh clone bubbles up Docker's raw `pull access denied` error when `sandcastle:<repo>` hasn't been built — looks like an auth issue, but the real fix is `tide build`.
* No upstream check existed, so the failure surfaced deep inside Sandcastle's `docker run` rather than as actionable CLI feedback.

## 💡 The Solution

* Run `build()` at the top of `tideRun`, right after repo/identity resolution and before any clack UI starts (streamed docker output otherwise garbles clack rendering).
* Lean on Docker's layer cache: the no-op case is cheap, and Dockerfile edits get picked up automatically — `tide run` and `tide build` stay convergent without a separate freshness check.
* Widen `RunOptions` with three optional test seams (`build`, `getGhIdentity`, `fetchTriageTree`) so the new build step is testable without spawning docker, `gh`, or hitting GitHub.

## 🏗 Architecture & Public Interface Changes
### 🗺 Interface Movements
| Interface / Symbol | Old Location / Status | New Location / Status | Notes |
| :--- | :--- | :--- | :--- |
| `RunOptions.build` | — | 🌐 Public (optional) | Test seam; defaults to `./build.ts` |
| `RunOptions.getGhIdentity` | — | 🌐 Public (optional) | Test seam; defaults to `../gh-identity` |
| `RunOptions.fetchTriageTree` | — | 🌐 Public (optional) | Test seam; defaults to `../github` |

### 📦 Package Breakdowns
#### 1. `src/cli`
*`tideRun` now invokes the build step before fetching the triage tree, and accepts injected dependencies for testing.*

<details>
<summary>🔍 View Interface Changes</summary>

```diff
  export interface RunOptions {
    repoRoot?: string;
    stdout?: (chunk: string) => void;
    stderr?: (chunk: string) => void;
+   build?: (options: BuildOptions) => Promise<number>;
+   getGhIdentity?: (options: GetGhIdentityOptions) => Promise<GhIdentity>;
+   fetchTriageTree?: (ghRepo: GhRepo) => Promise<TreeNode[]>;
  }

  export async function tideRun(options: RunOptions = {}): Promise<number>
```

Behavioural change inside `tideRun`:

```diff
  ensureSandcastleSymlink(repoRoot);

+ const buildExit = await build({ repoRoot, stdout, stderr });
+ if (buildExit !== 0) {
+   return buildExit;
+ }

  intro("tide run");
```
</details>

<sub>**Files changed:** [`run.ts`](https://github.com/m1yon/tide/pull/19/files#diff-dfa9baf011a9c38263c91af5d92745dd686bcc12a41d4974257c98da689589df), [`run.test.ts`](https://github.com/m1yon/tide/pull/19/files#diff-8ddf6e9a622d2440af27fb802251e7b9b9c1468385aee7f8a8c292ba90a7192d)</sub>

## 🧹 Housekeeping & Secondary Changes
* New `src/cli/run.test.ts` covers ordering (build before triage fetch, after gh-identity), pass-through of `repoRoot`/`stdout`/`stderr`, and short-circuit on non-zero build exit.

Closes #13