### PR TITLE
feat(sandbox): inject host gh auth token as GH_TOKEN

### DIFF
--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -37,6 +37,13 @@ function makeGhIdentity(log: CallLog) {
   };
 }
 
+function makeGhToken(log: CallLog) {
+  return (): Promise<string> => {
+    log.events.push("getGhToken");
+    return Promise.resolve("ghp_test");
+  };
+}
+
 interface FetchStub {
   tree: TreeNode[];
   calls: GhRepo[];
@@ -129,6 +136,7 @@ describe("tide run — build step", () => {
       stderr: captureStderr,
       build: makeBuild(buildStub, log),
       getGhIdentity: makeGhIdentity(log),
+      getGhToken: makeGhToken(log),
       fetchTriageTree: makeFetchTriageTree(fetchStub, log),
       baseBranchShellRunner: okBaseBranchRunner,
     });
@@ -153,6 +161,7 @@ describe("tide run — build step", () => {
       stderr: captureStderr,
       build: makeBuild(buildStub, log),
       getGhIdentity: makeGhIdentity(log),
+      getGhToken: makeGhToken(log),
       fetchTriageTree: makeFetchTriageTree(fetchStub, log),
       baseBranchShellRunner: okBaseBranchRunner,
     });
@@ -175,6 +184,7 @@ describe("tide run — build step", () => {
       stderr: captureStderr,
       build: makeBuild(buildStub, log),
       getGhIdentity: makeGhIdentity(log),
+      getGhToken: makeGhToken(log),
       fetchTriageTree: makeFetchTriageTree(fetchStub, log),
       baseBranchShellRunner: okBaseBranchRunner,
     });
@@ -195,6 +205,7 @@ describe("tide run — build step", () => {
       stderr: captureStderr,
       build: makeBuild(buildStub, log),
       getGhIdentity: makeGhIdentity(log),
+      getGhToken: makeGhToken(log),
       fetchTriageTree: makeFetchTriageTree(fetchStub, log),
       baseBranchShellRunner: okBaseBranchRunner,
     });
@@ -216,6 +227,7 @@ describe("tide run — build step", () => {
       stderr: captureStderr,
       build: makeBuild(buildStub, log),
       getGhIdentity: makeGhIdentity(log),
+      getGhToken: makeGhToken(log),
       fetchTriageTree: makeFetchTriageTree(fetchStub, log),
       baseBranchShellRunner: okBaseBranchRunner,
     });
@@ -224,6 +236,58 @@ describe("tide run — build step", () => {
     const buildIdx = log.events.indexOf("build");
     expect(ghIdx).toBeGreaterThanOrEqual(0);
     expect(buildIdx).toBeGreaterThan(ghIdx);
+  });
+
+  test("getGhToken runs after gh-identity and before docker build", async () => {
+    const log: CallLog = { events: [] };
+    const buildStub: BuildStub = { exitCode: 0, calls: [] };
+    const fetchStub: FetchStub = { tree: [], calls: [] };
+
+    await tideRun({
+      repoRoot,
+      stdout: captureStdout,
+      stderr: captureStderr,
+      build: makeBuild(buildStub, log),
+      getGhIdentity: makeGhIdentity(log),
+      getGhToken: () => {
+        log.events.push("getGhToken");
+        return Promise.resolve("ghp_test");
+      },
+      fetchTriageTree: makeFetchTriageTree(fetchStub, log),
+      baseBranchShellRunner: okBaseBranchRunner,
+    });
+
+    const ghIdx = log.events.indexOf("getGhIdentity");
+    const tokenIdx = log.events.indexOf("getGhToken");
+    const buildIdx = log.events.indexOf("build");
+    expect(ghIdx).toBeGreaterThanOrEqual(0);
+    expect(tokenIdx).toBeGreaterThan(ghIdx);
+    expect(buildIdx).toBeGreaterThan(tokenIdx);
+  });
+
+  test("getGhToken failure short-circuits before build", async () => {
+    const log: CallLog = { events: [] };
+    const buildStub: BuildStub = { exitCode: 0, calls: [] };
+    const fetchStub: FetchStub = { tree: [], calls: [] };
+
+    const code = await tideRun({
+      repoRoot,
+      stdout: captureStdout,
+      stderr: captureStderr,
+      build: makeBuild(buildStub, log),
+      getGhIdentity: makeGhIdentity(log),
+      getGhToken: () =>
+        Promise.reject(
+          new Error("tide: `gh auth token` failed. Run `gh auth login`")
+        ),
+      fetchTriageTree: makeFetchTriageTree(fetchStub, log),
+      baseBranchShellRunner: okBaseBranchRunner,
+    });
+
+    expect(code).toBe(1);
+    expect(buildStub.calls).toHaveLength(0);
+    expect(fetchStub.calls).toHaveLength(0);
+    expect(stderrChunks.join("")).toContain("gh auth login");
   });
 });
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -40,6 +40,10 @@ import {
   type GetGhIdentityOptions,
   type GhIdentity,
 } from "../gh-identity/index.ts";
+import {
+  getGhToken as defaultGetGhToken,
+  type GetGhTokenOptions,
+} from "../gh-token/index.ts";
 import type { ParentForLinear } from "../linear/index.ts";
 import {
   countCommitsAhead as defaultCountCommitsAhead,
@@ -63,6 +67,8 @@ export interface RunOptions {
   build?: (options: BuildOptions) => Promise<number>;
   /** gh-identity resolver. Tests stub this to avoid spawning `gh`. */
   getGhIdentity?: (options: GetGhIdentityOptions) => Promise<GhIdentity>;
+  /** gh-token resolver. Tests stub this to avoid spawning `gh`. */
+  getGhToken?: (options: GetGhTokenOptions) => Promise<string>;
   /** Triage-tree fetcher. Tests stub this to avoid hitting GitHub. */
   fetchTriageTree?: (ghRepo: GhRepo) => Promise<TreeNode[]>;
   /**
@@ -231,6 +237,7 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
   const stderr = options.stderr ?? ((s: string) => process.stderr.write(s));
   const build = options.build ?? defaultBuild;
   const getGhIdentity = options.getGhIdentity ?? defaultGetGhIdentity;
+  const getGhToken = options.getGhToken ?? defaultGetGhToken;
   const fetchTriageTree = options.fetchTriageTree ?? defaultFetchTriageTree;
 
   let repoRoot: string;
@@ -293,6 +300,18 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
   let ghRepo: GhRepo;
   try {
     ghRepo = await getGhIdentity({ repoRoot });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    stderr(`${msg}\n`);
+    return 1;
+  }
+
+  // Fetch the host's GitHub token and inject it into the sandbox so the
+  // agent's in-sandbox `gh` calls (issue close, future PR-create) are
+  // authenticated. Run before the docker build so missing auth fails fast.
+  // See ADR 0003 for the rationale.
+  try {
+    sandboxEnv.GH_TOKEN = await getGhToken({ repoRoot });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     stderr(`${msg}\n`);

--- a/src/env-loader/index.test.ts
+++ b/src/env-loader/index.test.ts
@@ -158,4 +158,19 @@ describe("env-loader", () => {
       /\/x\/\.tide\/\.env/
     );
   });
+
+  test("GH_TOKEN in .tide/.env is rejected with a hint that tide manages the key", () => {
+    writeEnv("LINEAR_API_KEY=lk\nANTHROPIC_API_KEY=ak\nGH_TOKEN=ghp_xxx\n");
+    let err: unknown = null;
+    try {
+      loadEnv({ repoRoot });
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    expect(msg).toContain("GH_TOKEN");
+    expect(msg).toContain("tide manages this");
+    expect(msg).toContain(".tide/.env");
+  });
 });

--- a/src/env-loader/index.ts
+++ b/src/env-loader/index.ts
@@ -19,6 +19,15 @@ export const CLAUDE_AUTH_KEYS = [
   "CLAUDE_CODE_OAUTH_TOKEN",
 ] as const;
 
+/**
+ * Keys that tide manages itself and the user must not set in `.tide/.env`.
+ *
+ * `GH_TOKEN` is fetched host-side from `gh auth token` and injected into the
+ * sandbox by tide (see ADR 0003). Allowing the user to override it would
+ * introduce a second source that drifts on rotation.
+ */
+export const FORBIDDEN_ENV_KEYS = ["GH_TOKEN"] as const;
+
 export interface LoadEnvOptions {
   /** Repo root containing `.tide/.env`. */
   repoRoot: string;
@@ -46,6 +55,7 @@ export function loadEnv(options: LoadEnvOptions): Record<string, string> {
 
   const missing = REQUIRED_ENV_KEYS.filter((k) => !(k in env));
   const hasAuth = CLAUDE_AUTH_KEYS.some((k) => k in env);
+  const forbidden = FORBIDDEN_ENV_KEYS.filter((k) => k in env);
 
   const errors: string[] = [];
   if (missing.length > 0) {
@@ -56,6 +66,11 @@ export function loadEnv(options: LoadEnvOptions): Record<string, string> {
   if (!hasAuth) {
     errors.push(
       `tide: ${envPath} must define ${CLAUDE_AUTH_KEYS.join(" or ")}`
+    );
+  }
+  for (const key of forbidden) {
+    errors.push(
+      `tide: ${envPath} sets ${key}; tide manages this — remove it from .tide/.env`
     );
   }
   if (errors.length > 0) {

--- a/src/gh-token/index.test.ts
+++ b/src/gh-token/index.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import { getGhToken, type Runner } from "./index.ts";
+
+function fakeRunner(result: {
+  exitCode: number;
+  stdout: string;
+  stderr?: string;
+}): Runner {
+  return () =>
+    Promise.resolve({
+      exitCode: result.exitCode,
+      stdout: result.stdout,
+      stderr: result.stderr ?? "",
+    });
+}
+
+async function captureError<T>(p: Promise<T>): Promise<unknown> {
+  try {
+    await p;
+    return null;
+  } catch (e) {
+    return e;
+  }
+}
+
+describe("gh-token", () => {
+  test("returns the trimmed token on zero exit", async () => {
+    const runner = fakeRunner({
+      exitCode: 0,
+      stdout: "ghp_abc123\n",
+    });
+    const token = await getGhToken({ repoRoot: "/r" }, runner);
+    expect(token).toBe("ghp_abc123");
+  });
+
+  test("throws when gh exits non-zero, with hint pointing at gh auth login", async () => {
+    const runner = fakeRunner({
+      exitCode: 1,
+      stdout: "",
+      stderr: "no oauth token",
+    });
+    const err = await captureError(getGhToken({ repoRoot: "/r" }, runner));
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    expect(msg).toMatch(/gh auth token.*failed/);
+    expect(msg).toContain("gh auth login");
+    expect(msg).toContain("no oauth token");
+  });
+
+  test("throws when stdout is empty (zero exit) with hint pointing at gh auth login", async () => {
+    const runner = fakeRunner({ exitCode: 0, stdout: "   \n" });
+    const err = await captureError(getGhToken({ repoRoot: "/r" }, runner));
+    expect(err).toBeInstanceOf(Error);
+    const msg = (err as Error).message;
+    expect(msg).toContain("empty");
+    expect(msg).toContain("gh auth login");
+  });
+
+  test("invokes gh with the configured cwd and --hostname github.com", async () => {
+    let capturedCwd: string | undefined;
+    let capturedArgs: readonly string[] | undefined;
+    let capturedCmd: string | undefined;
+    const runner: Runner = (cmd, args, cwd) => {
+      capturedCmd = cmd;
+      capturedCwd = cwd;
+      capturedArgs = args;
+      return Promise.resolve({
+        exitCode: 0,
+        stdout: "ghp_xyz\n",
+        stderr: "",
+      });
+    };
+
+    await getGhToken({ repoRoot: "/some/repo" }, runner);
+
+    expect(capturedCmd).toBe("gh");
+    expect(capturedCwd).toBe("/some/repo");
+    expect(capturedArgs).toEqual(["auth", "token", "--hostname", "github.com"]);
+  });
+});

--- a/src/gh-token/index.ts
+++ b/src/gh-token/index.ts
@@ -1,0 +1,79 @@
+import { spawn } from "node:child_process";
+
+export interface GetGhTokenOptions {
+  /** Repo root used as `cwd` for the `gh` invocation. */
+  repoRoot: string;
+}
+
+interface ExecResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+async function defaultRunner(
+  cmd: string,
+  args: readonly string[],
+  cwd: string
+): Promise<ExecResult> {
+  return await new Promise<ExecResult>((resolve, reject) => {
+    const child = spawn(cmd, args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf8");
+    });
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf8");
+    });
+    child.on("error", (err) => {
+      reject(err);
+    });
+    child.on("close", (code) => {
+      resolve({ exitCode: code ?? 0, stdout, stderr });
+    });
+  });
+}
+
+export type Runner = (
+  cmd: string,
+  args: readonly string[],
+  cwd: string
+) => Promise<ExecResult>;
+
+const AUTH_HINT =
+  "Run `gh auth login` (or `gh auth refresh`) on the host and retry.";
+
+/**
+ * Shells out to `gh auth token --hostname github.com`, returns the trimmed
+ * token. Throws on non-zero exit or empty stdout, with a hint pointing at
+ * `gh auth login`.
+ *
+ * Hostname is pinned to github.com to match the rest of tide's implicit
+ * github.com assumption (Linear URL builder, gh-identity error messaging).
+ */
+export async function getGhToken(
+  options: GetGhTokenOptions,
+  runner: Runner = defaultRunner
+): Promise<string> {
+  const result = await runner(
+    "gh",
+    ["auth", "token", "--hostname", "github.com"],
+    options.repoRoot
+  );
+  if (result.exitCode !== 0) {
+    const stderrTrimmed = result.stderr.trim();
+    throw new Error(
+      `tide: \`gh auth token\` failed (exit ${String(result.exitCode)})${stderrTrimmed === "" ? "" : `: ${stderrTrimmed}`}. ${AUTH_HINT}`
+    );
+  }
+
+  const token = result.stdout.trim();
+  if (token === "") {
+    throw new Error(
+      `tide: \`gh auth token\` returned empty stdout. ${AUTH_HINT}`
+    );
+  }
+
+  return token;
+}


### PR DESCRIPTION
## 🚩 The Problem

* In-sandbox `gh` calls (e.g. `gh issue close` after issue completion) had no credentials and silently failed.
* Future PR-create step (ADR 0001) needs an authenticated `gh` inside the sandbox too.
* Letting users hand-set `GH_TOKEN` in `.tide/.env` would create a second source that drifts on `gh auth refresh`.

## 💡 The Solution

* Carved out `src/gh-token/` (mirrors `src/gh-identity/`) — host-side `gh auth token --hostname github.com` resolver.
* `tideRun` calls it after `getGhIdentity`, injects the result into `sandboxEnv.GH_TOKEN` before the docker build so missing auth fails fast.
* `env-loader` now rejects `GH_TOKEN` in `.tide/.env` so the host token is the only source of truth.

## 🏗 Architecture & Public Interface Changes

### 🗺 Interface Movements
| Interface / Symbol | Old Location / Status | New Location / Status | Notes |
| :--- | :--- | :--- | :--- |
| `getGhToken` | — | `src/gh-token` 🌐 Public | New host-side fetcher, mirrors `getGhIdentity` |
| `GetGhTokenOptions`, `Runner` | — | `src/gh-token` 🌐 Public | Companion types; `Runner` for test injection |
| `FORBIDDEN_ENV_KEYS` | — | `src/env-loader` 🌐 Public | New constant; currently `["GH_TOKEN"]` |
| `RunOptions.getGhToken` | — | `src/cli/run` 🌐 Public | New optional injection point for tests |

### 📦 Package Breakdowns

#### 1. `src/gh-token` *(new)*
*Host-side `gh auth token` resolver. Pinned to `--hostname github.com` to match the rest of tide's implicit github.com assumption. Returns the trimmed token; throws with a `gh auth login` hint on non-zero exit or empty stdout. `Runner` injection mirrors `gh-identity`.*

<details>
<summary>🔍 View Interface</summary>

```diff
+ export interface GetGhTokenOptions { repoRoot: string }

+ export type Runner = (
+   cmd: string,
+   args: readonly string[],
+   cwd: string,
+ ) => Promise<ExecResult>

+ export function getGhToken(
+   options: GetGhTokenOptions,
+   runner?: Runner,
+ ): Promise<string>
```
</details>

<sub>**Files changed:** [`index.ts`](https://github.com/m1yon/tide/pull/21/files#diff-6546d02da7b8eeea2953e8fc1e0e1fb2278aeedd58e01261a126412aecce35c7), [`index.test.ts`](https://github.com/m1yon/tide/pull/21/files#diff-65bed590f8f9f16e9d827ad1189f7394a510bbf1b0547451976f05e9fdcc8d5e)</sub>

---

#### 2. `src/env-loader`
*Adds a forbidden-keys gate. `GH_TOKEN` in `.tide/.env` now fails fast with "tide manages this — remove it from .tide/.env" so there is exactly one source for the sandbox's gh credential.*

<details>
<summary>🔍 View Interface</summary>

```diff
+ export const FORBIDDEN_ENV_KEYS = ["GH_TOKEN"] as const
```
</details>

<sub>**Files changed:** [`index.ts`](https://github.com/m1yon/tide/pull/21/files#diff-e68abe08cf402c8db1ff22b306381d245f7883fee0fbc2ef1d43cfc80636a06d), [`index.test.ts`](https://github.com/m1yon/tide/pull/21/files#diff-c45d044968c591e56fb481ea7e3d921f0f82d8518da1c6702f486f3425be477b)</sub>

---

#### 3. `src/cli/run`
*`tideRun` now fetches the host token between `getGhIdentity` and the docker build, then assigns `sandboxEnv.GH_TOKEN`. Failures short-circuit before the build to surface auth problems quickly. See ADR 0003 for the rationale.*

<details>
<summary>🔍 View Interface</summary>

```diff
  export interface RunOptions {
    ...
+   getGhToken?: (options: GetGhTokenOptions) => Promise<string>
    ...
  }
```
</details>

<sub>**Files changed:** [`run.ts`](https://github.com/m1yon/tide/pull/21/files#diff-dfa9baf011a9c38263c91af5d92745dd686bcc12a41d4974257c98da689589df), [`run.test.ts`](https://github.com/m1yon/tide/pull/21/files#diff-8ddf6e9a622d2440af27fb802251e7b9b9c1468385aee7f8a8c292ba90a7192d)</sub>

## 🧹 Housekeeping & Secondary Changes

* No housekeeping in this PR. Rationale doc (`docs/adr/0003-sandbox-gh-auth-host-fetched.md`) already landed on `master` ahead of this change.

Closes #20