### PR TITLE
feat: support Standalone Issues as runnable roots alongside PRDs

### DIFF
--- a/.tide/prompt-standalone.md
+++ b/.tide/prompt-standalone.md
@@ -1,0 +1,47 @@
+You are working on Linear issue {{ISSUE_ID}}.
+
+Branch: {{SOURCE_BRANCH}} (PR will merge into {{TARGET_BRANCH}})
+
+## Issue: {{ISSUE_TITLE}}
+
+{{ISSUE_CONTENT}}
+
+## CONTEXT
+
+Recent commits on this feature branch (since it diverged from `{{TARGET_BRANCH}}`):
+
+<recent-commits>
+
+!`git log {{TARGET_BRANCH}}..HEAD --oneline`
+
+</recent-commits>
+
+## Instructions
+
+1. **Explore** — Explore the repo and fill your context window with relevant information that will allow you to complete the task. Pay extra attention to test files that touch the relevant parts of the code.
+2. **Plan** — smallest viable change.
+3. **Execute** — solve the issue above. If applicable, use RGR to complete the task:
+   1. RED: write one test
+   2. GREEN: write the implementation to pass that test
+   3. REPEAT until done
+   4. REFACTOR the code
+4. **Verify** — run the project's test suite. If any test fails, fix it before committing. If a failure is unrelated/unfixable, emit `<promise>BLOCKED</promise>` (see "Ending the iteration").
+5. **Commit** — single commit. Ensure any configured pre-commit hooks (lint, format, etc.) ran successfully; if they didn't fire, run the project's setup command and retry. If still not firing, emit `<promise>BLOCKED</promise>`. The commit message MUST:
+   1. Start with `ref {{ISSUE_ID}}` (Linear's non-closing magic word — surfaces the commit on the issue's timeline without forcing a state transition)
+   2. Summarise what was done in one short line
+   3. Be concise. The host will transition the issue to _Done_ when you emit DONE.
+
+## Rules
+
+- Work on **only** this issue ({{ISSUE_ID}}).
+- Every commit on this branch is prefixed with `ref {{ISSUE_ID}}`. The host (tide), not you, transitions the issue's Linear state.
+- Do not leave commented-out code or TODO comments in committed code.
+- Do **not** call `gh issue close`, `linear` CLI commands, or any other state-mutating Linear/GitHub command. The host owns those writes.
+- If you are blocked (missing context, failing tests you cannot fix, external dependency), emit `<promise>BLOCKED</promise>` instead of DONE.
+
+# Ending the iteration
+
+Emit one of two signals on the very last line of your response, exactly:
+
+- `<promise>DONE</promise>` — issue is fully implemented and committed. The host will transition it to _Done_ in Linear.
+- `<promise>BLOCKED</promise>` — you are gracefully stuck (missing context, failing tests you cannot fix, external dependency, etc.). Explain what's blocking you in your final message; the host will summarise and flag the issue for human review. Do **not** emit DONE on a partial or speculative completion.

--- a/src/cli/init-templates.d.ts
+++ b/src/cli/init-templates.d.ts
@@ -10,6 +10,10 @@ declare module "*/init-templates/prompt.md" {
   const content: string;
   export default content;
 }
+declare module "*/init-templates/prompt-standalone.md" {
+  const content: string;
+  export default content;
+}
 declare module "*/init-templates/.env.example" {
   const content: string;
   export default content;

--- a/src/cli/init-templates/prompt-standalone.md
+++ b/src/cli/init-templates/prompt-standalone.md
@@ -1,0 +1,47 @@
+You are working on Linear issue {{ISSUE_ID}}.
+
+Branch: {{SOURCE_BRANCH}} (PR will merge into {{TARGET_BRANCH}})
+
+## Issue: {{ISSUE_TITLE}}
+
+{{ISSUE_CONTENT}}
+
+## CONTEXT
+
+Recent commits on this feature branch (since it diverged from `{{TARGET_BRANCH}}`):
+
+<recent-commits>
+
+!`git log {{TARGET_BRANCH}}..HEAD --oneline`
+
+</recent-commits>
+
+## Instructions
+
+1. **Explore** — Explore the repo and fill your context window with relevant information that will allow you to complete the task. Pay extra attention to test files that touch the relevant parts of the code.
+2. **Plan** — smallest viable change.
+3. **Execute** — solve the issue above. If applicable, use RGR to complete the task:
+   1. RED: write one test
+   2. GREEN: write the implementation to pass that test
+   3. REPEAT until done
+   4. REFACTOR the code
+4. **Verify** — run the project's test suite. If any test fails, fix it before committing. If a failure is unrelated/unfixable, emit `<promise>BLOCKED</promise>` (see "Ending the iteration").
+5. **Commit** — single commit. Ensure any configured pre-commit hooks (lint, format, etc.) ran successfully; if they didn't fire, run the project's setup command and retry. If still not firing, emit `<promise>BLOCKED</promise>`. The commit message MUST:
+   1. Start with `ref {{ISSUE_ID}}` (Linear's non-closing magic word — surfaces the commit on the issue's timeline without forcing a state transition)
+   2. Summarise what was done in one short line
+   3. Be concise. The host will transition the issue to _Done_ when you emit DONE.
+
+## Rules
+
+- Work on **only** this issue ({{ISSUE_ID}}).
+- Every commit on this branch is prefixed with `ref {{ISSUE_ID}}`. The host (tide), not you, transitions the issue's Linear state.
+- Do not leave commented-out code or TODO comments in committed code.
+- Do **not** call `gh issue close`, `linear` CLI commands, or any other state-mutating Linear/GitHub command. The host owns those writes.
+- If you are blocked (missing context, failing tests you cannot fix, external dependency), emit `<promise>BLOCKED</promise>` instead of DONE.
+
+# Ending the iteration
+
+Emit one of two signals on the very last line of your response, exactly:
+
+- `<promise>DONE</promise>` — issue is fully implemented and committed. The host will transition it to _Done_ in Linear.
+- `<promise>BLOCKED</promise>` — you are gracefully stuck (missing context, failing tests you cannot fix, external dependency, etc.). Explain what's blocking you in your final message; the host will summarise and flag the issue for human review. Do **not** emit DONE on a partial or speculative completion.

--- a/src/cli/init.test.ts
+++ b/src/cli/init.test.ts
@@ -35,7 +35,7 @@ describe("tide init", () => {
     rmSync(workDir, { recursive: true, force: true });
   });
 
-  test("creates .tide/ with all five files at the discovered repo root", () => {
+  test("creates .tide/ with all six files at the discovered repo root", () => {
     const code = init({
       repoRoot,
       stdout: captureStdout,
@@ -47,8 +47,26 @@ describe("tide init", () => {
     expect(existsSync(join(tideDir, "config.ts"))).toBe(true);
     expect(existsSync(join(tideDir, "Dockerfile"))).toBe(true);
     expect(existsSync(join(tideDir, "prompt.md"))).toBe(true);
+    expect(existsSync(join(tideDir, "prompt-standalone.md"))).toBe(true);
     expect(existsSync(join(tideDir, ".env.example"))).toBe(true);
     expect(existsSync(join(tideDir, ".gitignore"))).toBe(true);
+  });
+
+  test("prompt-standalone.md template substitutes ISSUE_* without referencing a parent PRD", () => {
+    init({ repoRoot, stdout: captureStdout, stderr: captureStderr });
+    const prompt = readFileSync(
+      join(repoRoot, ".tide", "prompt-standalone.md"),
+      "utf8"
+    );
+    expect(prompt).toContain("{{ISSUE_ID}}");
+    expect(prompt).toContain("{{ISSUE_TITLE}}");
+    expect(prompt).toContain("{{ISSUE_CONTENT}}");
+    expect(prompt).toContain("{{SOURCE_BRANCH}}");
+    expect(prompt).toContain("{{TARGET_BRANCH}}");
+    // No parent-PRD references — Standalone Issues run without one.
+    expect(prompt).not.toContain("{{PRD_CONTENT}}");
+    expect(prompt).not.toContain("{{PARENT_ID}}");
+    expect(prompt).not.toContain("Parent PRD");
   });
 
   test("config.ts template references linear.team as the required field", () => {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -8,6 +8,7 @@ import { discoverRepoRoot } from "../repo-discovery/index.ts";
 import configTsRaw from "./init-templates/config.ts" with { type: "text" };
 import dockerfile from "./init-templates/Dockerfile" with { type: "text" };
 import promptMd from "./init-templates/prompt.md" with { type: "text" };
+import promptStandaloneMd from "./init-templates/prompt-standalone.md" with { type: "text" };
 import envExample from "./init-templates/.env.example" with { type: "text" };
 import gitignore from "./init-templates/.gitignore" with { type: "text" };
 
@@ -21,6 +22,7 @@ const TARGETS = [
   { name: "config.ts", content: configTs },
   { name: "Dockerfile", content: dockerfile },
   { name: "prompt.md", content: promptMd },
+  { name: "prompt-standalone.md", content: promptStandaloneMd },
   { name: ".env.example", content: envExample },
   { name: ".gitignore", content: gitignore },
 ] as const;

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -1681,6 +1681,64 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
     expect(out).toContain("non-PRD with children");
   });
 
+  test("does not surface the children-error when the user cancels at the pre-flight (standalone with children)", async () => {
+    // PER-56 acceptance: the children-check happens AFTER the user confirms
+    // the pre-flight. Cancelling the run at the confirm prompt — even when
+    // the picked Standalone Issue would otherwise fail validation — must
+    // exit cleanly with no structural error message.
+    const issue = makeStandaloneIssue({ identifier: "ENG-7" });
+    let fetchSubIssuesCalls = 0;
+    let runIssueQueueCalls = 0;
+    let transitionCalls = 0;
+
+    const code = await runQueueAfterPick({
+      picked: standaloneRoot(issue),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => {
+        fetchSubIssuesCalls += 1;
+        return Promise.resolve([
+          {
+            id: "uuid-child",
+            identifier: "ENG-77",
+            title: "Sub-task",
+            state: "Backlog",
+            stateType: "backlog",
+            labels: [],
+            blockedBy: [],
+          },
+        ] as SubIssue[]);
+      },
+      runIssueQueue: () => {
+        runIssueQueueCalls += 1;
+        return Promise.resolve({ completed: 0, flipped: 0 });
+      },
+      runPrTailStep: () =>
+        Promise.resolve({
+          outcome: { kind: "opted-out" },
+          outroMessage: "x",
+          exitCode: 0,
+        } satisfies PrTailStepResult),
+      confirmRun: () => Promise.resolve(false),
+      confirmPr: () => Promise.resolve(true),
+      transitionRootToInProgress: () => {
+        transitionCalls += 1;
+        return Promise.resolve();
+      },
+    });
+
+    expect(code).toBe(0);
+    expect(fetchSubIssuesCalls).toBe(0);
+    expect(runIssueQueueCalls).toBe(0);
+    expect(transitionCalls).toBe(0);
+    const out = stdoutChunks.join("");
+    expect(out).not.toContain("non-PRD with children");
+  });
+
   test("logs the BLOCKED warning when the standalone iteration ends on a flip (no completion)", async () => {
     const issue = makeStandaloneIssue({ identifier: "ENG-7" });
 

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -1768,6 +1768,83 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
     expect(out).toContain("Issue ENG-7 is flipped to `ready-for-human`");
     // No-merge warning for "Issue" rather than "PRD".
     expect(out).toContain("Issue ENG-7 will not auto-transition");
+    // BLOCKED hand-off warning fires BEFORE the no-merge warning so it's
+    // the first thing the user reads after the queue ends.
+    const flippedIdx = out.indexOf("is flipped to `ready-for-human`");
+    const noMergeIdx = out.indexOf("will not auto-transition");
+    expect(flippedIdx).toBeGreaterThanOrEqual(0);
+    expect(noMergeIdx).toBeGreaterThan(flippedIdx);
+  });
+
+  test("does not log the BLOCKED warning when the standalone iteration completes (DONE)", async () => {
+    const issue = makeStandaloneIssue({ identifier: "ENG-7" });
+
+    const code = await runQueueAfterPick({
+      picked: standaloneRoot(issue),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
+      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runPrTailStep: () =>
+        Promise.resolve({
+          outcome: { kind: "opened", url: "https://example/pr/1" },
+          outroMessage: "Done. PR opened: https://example/pr/1",
+          exitCode: 0,
+        } satisfies PrTailStepResult),
+      confirmRun: () => Promise.resolve(true),
+      confirmPr: () => Promise.resolve(true),
+      transitionRootToInProgress: () => Promise.resolve(),
+    });
+
+    expect(code).toBe(0);
+    const out = stdoutChunks.join("");
+    expect(out).not.toContain("is flipped to `ready-for-human`");
+  });
+
+  test("PRD-rooted run with a flipped sub-issue does not log the Standalone BLOCKED warning", async () => {
+    const picked = makePRD({ identifier: "ENG-1", title: "Example PRD" });
+
+    const code = await runQueueAfterPick({
+      picked: prdRoot(picked),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () =>
+        Promise.resolve([
+          makeSubIssue({
+            id: "uuid-sub-1",
+            identifier: "ENG-2",
+            title: "Sub-task",
+          }),
+        ]),
+      // The PRD-rooted queue ran one sub-issue and flipped it to
+      // `ready-for-human`. The Standalone-specific warning must not fire —
+      // the per-sub-issue warning (logged inside the runner, not here) is
+      // the only BLOCKED hand-off the user should see.
+      runIssueQueue: () => Promise.resolve({ completed: 0, flipped: 1 }),
+      runPrTailStep: () =>
+        Promise.resolve({
+          outcome: { kind: "opted-out" },
+          outroMessage: "Done. PR step skipped (you opted out at pre-flight).",
+          exitCode: 0,
+        } satisfies PrTailStepResult),
+      confirmRun: () => Promise.resolve(true),
+      confirmPr: () => Promise.resolve(false),
+      transitionRootToInProgress: () => Promise.resolve(),
+    });
+
+    expect(code).toBe(0);
+    const out = stdoutChunks.join("");
+    expect(out).not.toContain("is flipped to `ready-for-human`");
+    // The PRD's existing no-merge warning is still expected.
+    expect(out).toContain("PRD ENG-1 will not auto-transition");
   });
 
   test("pre-flight summary text branches per root kind: 'Standalone Issue: 1 iteration'", async () => {

--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -12,12 +12,18 @@ import {
 } from "./run.ts";
 import type { BuildOptions } from "./build.ts";
 import type { GhIdentity } from "../gh-identity/index.ts";
-import type { LinearContext, PRD, SubIssue } from "../linear/index.ts";
+import type {
+  LinearContext,
+  PRD,
+  StandaloneIssue,
+  SubIssue,
+} from "../linear/index.ts";
 import type {
   PrSubmissionResult,
   ShellResult,
   ShellRunner,
 } from "../pr-submission/index.ts";
+import type { RootRef } from "../selector/index.ts";
 import type { TideConfig } from "../config-loader/index.ts";
 
 interface CallLog {
@@ -64,19 +70,32 @@ function makeListPRDs(stub: ListPRDsStub, log: CallLog) {
   };
 }
 
-interface PickPRDStub {
-  /** Index into the prds list to pick. */
-  pickIndex: number;
+interface PickRootStub {
+  /** Index into the prds list to pick. Mutually exclusive with
+   * `standalonePickIndex`. */
+  pickIndex?: number;
+  /** Index into the standaloneIssues list to pick. */
+  standalonePickIndex?: number;
   calls: number;
 }
 
-function makePickPRD(stub: PickPRDStub, log: CallLog) {
-  return (prds: readonly PRD[]): Promise<PRD> => {
+function makePickRoot(stub: PickRootStub, log: CallLog) {
+  return (input: {
+    prds: readonly PRD[];
+    standaloneIssues: readonly StandaloneIssue[];
+  }): Promise<RootRef> => {
     stub.calls += 1;
-    log.events.push("pickPRD");
-    const picked = prds[stub.pickIndex];
-    if (!picked) throw new Error("pickPRD stub: index out of range");
-    return Promise.resolve(picked);
+    log.events.push("pickRoot");
+    if (stub.standalonePickIndex !== undefined) {
+      const issue = input.standaloneIssues[stub.standalonePickIndex];
+      if (!issue)
+        throw new Error("pickRoot stub: standalone index out of range");
+      return Promise.resolve({ kind: "standalone", issue });
+    }
+    const idx = stub.pickIndex ?? 0;
+    const prd = input.prds[idx];
+    if (!prd) throw new Error("pickRoot stub: PRD index out of range");
+    return Promise.resolve({ kind: "prd", prd });
   };
 }
 
@@ -91,6 +110,29 @@ function makePRD(overrides: Partial<PRD> = {}): PRD {
     updatedAt: new Date("2026-04-01T00:00:00Z"),
     readyForAgentCount: 2,
     readyForHumanCount: 0,
+    ...overrides,
+  };
+}
+
+function prdRoot(prd: PRD): RootRef {
+  return { kind: "prd", prd };
+}
+
+function standaloneRoot(issue: StandaloneIssue): RootRef {
+  return { kind: "standalone", issue };
+}
+
+function makeStandaloneIssue(
+  overrides: Partial<StandaloneIssue> = {}
+): StandaloneIssue {
+  return {
+    id: "uuid-iss-7",
+    identifier: "ENG-7",
+    title: "Fix flaky export",
+    state: "Backlog",
+    branchName: "user/eng-7-fix-flaky-export",
+    url: "https://linear.app/eng/issue/ENG-7",
+    updatedAt: new Date("2026-04-10T00:00:00Z"),
     ...overrides,
   };
 }
@@ -189,6 +231,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
       getGhIdentity: makeGhIdentity(log),
       getGhToken: makeGhToken(log),
       listPRDs: makeListPRDs(listStub, log),
+      listStandaloneIssues: () => Promise.resolve([]),
       baseBranchShellRunner: okBaseBranchRunner,
     });
 
@@ -214,6 +257,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
       getGhIdentity: makeGhIdentity(log),
       getGhToken: makeGhToken(log),
       listPRDs: makeListPRDs(listStub, log),
+      listStandaloneIssues: () => Promise.resolve([]),
       baseBranchShellRunner: okBaseBranchRunner,
     });
 
@@ -237,6 +281,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
       getGhIdentity: makeGhIdentity(log),
       getGhToken: makeGhToken(log),
       listPRDs: makeListPRDs(listStub, log),
+      listStandaloneIssues: () => Promise.resolve([]),
       baseBranchShellRunner: okBaseBranchRunner,
     });
 
@@ -245,11 +290,11 @@ describe("tide run — early gates and Linear PRD selector", () => {
     expect(listStub.calls).toHaveLength(0);
   });
 
-  test("empty PRD list exits cleanly without invoking the selector", async () => {
+  test("empty PRD and Standalone Issue lists exit cleanly without invoking the selector", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
     const listStub: ListPRDsStub = { prds: [], calls: [] };
-    const pickStub: PickPRDStub = { pickIndex: 0, calls: 0 };
+    const pickStub: PickRootStub = { pickIndex: 0, calls: 0 };
 
     const code = await tideRun({
       repoRoot,
@@ -259,7 +304,8 @@ describe("tide run — early gates and Linear PRD selector", () => {
       getGhIdentity: makeGhIdentity(log),
       getGhToken: makeGhToken(log),
       listPRDs: makeListPRDs(listStub, log),
-      pickPRD: makePickPRD(pickStub, log),
+      listStandaloneIssues: () => Promise.resolve([]),
+      pickRoot: makePickRoot(pickStub, log),
       baseBranchShellRunner: okBaseBranchRunner,
     });
 
@@ -267,7 +313,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
     expect(pickStub.calls).toBe(0);
   });
 
-  test("non-empty PRD list invokes pickPRD and dispatches the picked PRD to runQueueAfterPick", async () => {
+  test("non-empty PRD list invokes pickRoot and dispatches the picked PRD to runQueueAfterPick", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
     const listStub: ListPRDsStub = {
@@ -277,8 +323,8 @@ describe("tide run — early gates and Linear PRD selector", () => {
       ],
       calls: [],
     };
-    const pickStub: PickPRDStub = { pickIndex: 1, calls: 0 };
-    const queueCalls: PRD[] = [];
+    const pickStub: PickRootStub = { pickIndex: 1, calls: 0 };
+    const queueCalls: RootRef[] = [];
 
     const code = await tideRun({
       repoRoot,
@@ -288,7 +334,8 @@ describe("tide run — early gates and Linear PRD selector", () => {
       getGhIdentity: makeGhIdentity(log),
       getGhToken: makeGhToken(log),
       listPRDs: makeListPRDs(listStub, log),
-      pickPRD: makePickPRD(pickStub, log),
+      listStandaloneIssues: () => Promise.resolve([]),
+      pickRoot: makePickRoot(pickStub, log),
       runQueueAfterPick: (opts) => {
         log.events.push("runQueueAfterPick");
         queueCalls.push(opts.picked);
@@ -299,14 +346,51 @@ describe("tide run — early gates and Linear PRD selector", () => {
 
     expect(code).toBe(0);
     expect(pickStub.calls).toBe(1);
-    // The post-pick orchestration is invoked exactly once with the picked PRD.
     expect(queueCalls).toHaveLength(1);
-    expect(queueCalls[0]?.identifier).toBe("ENG-8");
+    const root = queueCalls[0];
+    if (root?.kind !== "prd") throw new Error("expected PRD root");
+    expect(root.prd.identifier).toBe("ENG-8");
 
-    const pickIdx = log.events.indexOf("pickPRD");
+    const pickIdx = log.events.indexOf("pickRoot");
     const queueIdx = log.events.indexOf("runQueueAfterPick");
     expect(pickIdx).toBeGreaterThanOrEqual(0);
     expect(queueIdx).toBeGreaterThan(pickIdx);
+  });
+
+  test("non-empty Standalone Issue list invokes pickRoot and dispatches the picked Issue", async () => {
+    const log: CallLog = { events: [] };
+    const buildStub: BuildStub = { exitCode: 0, calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const pickStub: PickRootStub = { standalonePickIndex: 0, calls: 0 };
+    const queueCalls: RootRef[] = [];
+
+    const code = await tideRun({
+      repoRoot,
+      stdout: captureStdout,
+      stderr: captureStderr,
+      build: makeBuild(buildStub, log),
+      getGhIdentity: makeGhIdentity(log),
+      getGhToken: makeGhToken(log),
+      listPRDs: makeListPRDs(listStub, log),
+      listStandaloneIssues: () =>
+        Promise.resolve([
+          makeStandaloneIssue({ id: "uuid-iss-7", identifier: "ENG-7" }),
+        ]),
+      pickRoot: makePickRoot(pickStub, log),
+      runQueueAfterPick: (opts) => {
+        queueCalls.push(opts.picked);
+        return Promise.resolve(0);
+      },
+      baseBranchShellRunner: okBaseBranchRunner,
+    });
+
+    expect(code).toBe(0);
+    expect(queueCalls).toHaveLength(1);
+    const root = queueCalls[0];
+    if (root?.kind !== "standalone") {
+      throw new Error("expected standalone root");
+    }
+    expect(root.issue.identifier).toBe("ENG-7");
   });
 
   test("listPRDs receives the LINEAR_API_KEY and team key from config", async () => {
@@ -322,6 +406,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
       getGhIdentity: makeGhIdentity(log),
       getGhToken: makeGhToken(log),
       listPRDs: makeListPRDs(listStub, log),
+      listStandaloneIssues: () => Promise.resolve([]),
       baseBranchShellRunner: okBaseBranchRunner,
     });
 
@@ -345,6 +430,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
       getGhIdentity: makeGhIdentity(log),
       getGhToken: makeGhToken(log),
       listPRDs: makeListPRDs(listStub, log),
+      listStandaloneIssues: () => Promise.resolve([]),
       baseBranchShellRunner: okBaseBranchRunner,
     });
 
@@ -364,6 +450,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
       getGhIdentity: makeGhIdentity(log),
       getGhToken: makeGhToken(log),
       listPRDs: makeListPRDs(listStub, log),
+      listStandaloneIssues: () => Promise.resolve([]),
       baseBranchShellRunner: okBaseBranchRunner,
     });
 
@@ -389,6 +476,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
         return Promise.resolve("ghp_test");
       },
       listPRDs: makeListPRDs(listStub, log),
+      listStandaloneIssues: () => Promise.resolve([]),
       baseBranchShellRunner: okBaseBranchRunner,
     });
 
@@ -416,6 +504,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
           new Error("tide: `gh auth token` failed. Run `gh auth login`")
         ),
       listPRDs: makeListPRDs(listStub, log),
+      listStandaloneIssues: () => Promise.resolve([]),
       baseBranchShellRunner: okBaseBranchRunner,
     });
 
@@ -439,6 +528,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
       getGhIdentity: makeGhIdentity(log),
       getGhToken: makeGhToken(log),
       listPRDs,
+      listStandaloneIssues: () => Promise.resolve([]),
       baseBranchShellRunner: okBaseBranchRunner,
     });
 
@@ -511,9 +601,9 @@ describe("runPrTailStep", () => {
     ghRepo: baseGhRepo,
     branch: "feature/per-32",
     baseBranch: "master",
-    parentIdentifier: "MEC-123",
-    parentTitle: "PRD: example feature",
-    parentUrl: "https://linear.app/acme/issue/MEC-123",
+    rootIdentifier: "MEC-123",
+    rootTitle: "PRD: example feature",
+    rootUrl: "https://linear.app/acme/issue/MEC-123",
     subIssues: [{ number: 8, title: "Foundation tracer" }],
     repoRoot: "/repo",
     config: baseConfig,
@@ -902,7 +992,7 @@ describe("runQueueAfterPick — feature-branch guard", () => {
     let confirmPrCalls = 0;
 
     const code = await runQueueAfterPick({
-      picked,
+      picked: prdRoot(picked),
       ghRepo: { owner: "acme", repo: "widget" },
       // baseBranch matches the PRD's branchName — user is already on the
       // feature branch and would otherwise stack the PR on top of itself.
@@ -961,7 +1051,7 @@ describe("runQueueAfterPick — feature-branch guard", () => {
     let fetchSubIssuesCalls = 0;
 
     await runQueueAfterPick({
-      picked,
+      picked: prdRoot(picked),
       ghRepo: { owner: "acme", repo: "widget" },
       baseBranch: "master",
       linearCtx: { apiKey: "lk", teamKey: "ENG" },
@@ -1022,7 +1112,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
     const transitionCalls: { ctx: LinearContext; issueId: string }[] = [];
 
     await runQueueAfterPick({
-      picked,
+      picked: prdRoot(picked),
       ghRepo: { owner: "acme", repo: "widget" },
       baseBranch: "master",
       linearCtx: { apiKey: "lk", teamKey: "ENG" },
@@ -1053,8 +1143,8 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
         events.push("confirmPr");
         return Promise.resolve(true);
       },
-      transitionPrdToInProgress: (ctx, issueId) => {
-        events.push("transitionPrdToInProgress");
+      transitionRootToInProgress: (ctx, issueId) => {
+        events.push("transitionRootToInProgress");
         transitionCalls.push({ ctx, issueId });
         return Promise.resolve();
       },
@@ -1063,7 +1153,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
     expect(transitionCalls).toHaveLength(1);
     expect(transitionCalls[0]?.issueId).toBe("uuid-eng-7");
     // Order: confirms run first, THEN PRD transitions, THEN queue starts.
-    const tIdx = events.indexOf("transitionPrdToInProgress");
+    const tIdx = events.indexOf("transitionRootToInProgress");
     const cRunIdx = events.indexOf("confirmRun");
     const cPrIdx = events.indexOf("confirmPr");
     const qIdx = events.indexOf("runIssueQueue");
@@ -1079,7 +1169,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
     let runIssueQueueCalls = 0;
 
     const code = await runQueueAfterPick({
-      picked,
+      picked: prdRoot(picked),
       ghRepo: { owner: "acme", repo: "widget" },
       baseBranch: "master",
       linearCtx: { apiKey: "lk", teamKey: "ENG" },
@@ -1099,7 +1189,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
         } satisfies PrTailStepResult),
       confirmRun: () => Promise.resolve(false),
       confirmPr: () => Promise.resolve(true),
-      transitionPrdToInProgress: () => {
+      transitionRootToInProgress: () => {
         transitionCalls += 1;
         return Promise.resolve();
       },
@@ -1115,7 +1205,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
     let runIssueQueueCalls = 0;
 
     const code = await runQueueAfterPick({
-      picked,
+      picked: prdRoot(picked),
       ghRepo: { owner: "acme", repo: "widget" },
       baseBranch: "master",
       linearCtx: { apiKey: "lk", teamKey: "ENG" },
@@ -1135,7 +1225,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
         } satisfies PrTailStepResult),
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(true),
-      transitionPrdToInProgress: () =>
+      transitionRootToInProgress: () =>
         Promise.reject(new Error("Linear API key invalid")),
     });
 
@@ -1156,7 +1246,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
     let capturedBaseBranch: string | undefined;
 
     await runQueueAfterPick({
-      picked,
+      picked: prdRoot(picked),
       ghRepo: { owner: "acme", repo: "widget" },
       baseBranch: "main",
       linearCtx: { apiKey: "lk", teamKey: "ENG" },
@@ -1176,7 +1266,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
         } satisfies PrTailStepResult),
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(true),
-      transitionPrdToInProgress: () => Promise.resolve(),
+      transitionRootToInProgress: () => Promise.resolve(),
     });
 
     expect(capturedBaseBranch).toBe("main");
@@ -1241,7 +1331,7 @@ describe("runQueueAfterPick — ready-for-human preflight skip log", () => {
     ];
 
     await runQueueAfterPick({
-      picked,
+      picked: prdRoot(picked),
       ghRepo: { owner: "acme", repo: "widget" },
       baseBranch: "master",
       linearCtx: { apiKey: "lk", teamKey: "ENG" },
@@ -1258,7 +1348,7 @@ describe("runQueueAfterPick — ready-for-human preflight skip log", () => {
         } satisfies PrTailStepResult),
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(false),
-      transitionPrdToInProgress: () => Promise.resolve(),
+      transitionRootToInProgress: () => Promise.resolve(),
     });
 
     const out = stdoutChunks.join("");
@@ -1283,7 +1373,7 @@ describe("runQueueAfterPick — ready-for-human preflight skip log", () => {
     ];
 
     await runQueueAfterPick({
-      picked,
+      picked: prdRoot(picked),
       ghRepo: { owner: "acme", repo: "widget" },
       baseBranch: "master",
       linearCtx: { apiKey: "lk", teamKey: "ENG" },
@@ -1300,7 +1390,7 @@ describe("runQueueAfterPick — ready-for-human preflight skip log", () => {
         } satisfies PrTailStepResult),
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(false),
-      transitionPrdToInProgress: () => Promise.resolve(),
+      transitionRootToInProgress: () => Promise.resolve(),
     });
 
     const out = stdoutChunks.join("");
@@ -1338,7 +1428,7 @@ describe("runQueueAfterPick — end-of-run no-merge warning", () => {
     tail: (opts: RunPrTailStepOptions) => Promise<PrTailStepResult>
   ) {
     return {
-      picked,
+      picked: prdRoot(picked),
       ghRepo: { owner: "acme", repo: "widget" },
       baseBranch: "master",
       linearCtx: { apiKey: "lk", teamKey: "ENG" },
@@ -1350,7 +1440,7 @@ describe("runQueueAfterPick — end-of-run no-merge warning", () => {
       runPrTailStep: tail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(true),
-      transitionPrdToInProgress: () => Promise.resolve(),
+      transitionRootToInProgress: () => Promise.resolve(),
     };
   }
 
@@ -1434,5 +1524,251 @@ describe("runQueueAfterPick — end-of-run no-merge warning", () => {
     expect(code).toBe(0);
     const out = stdoutChunks.join("");
     expect(out).not.toContain("will not auto-transition");
+  });
+});
+
+describe("runQueueAfterPick — Standalone Issue root", () => {
+  type WriteFn = typeof process.stdout.write;
+  let stdoutChunks: string[];
+  let originalStdoutWrite: WriteFn;
+
+  const baseConfig: TideConfig = {
+    linear: { team: "ENG" },
+    sandbox: { mounts: [] },
+    hooks: { onSandboxReady: [] },
+  };
+
+  beforeEach(() => {
+    stdoutChunks = [];
+    originalStdoutWrite = process.stdout.write.bind(process.stdout);
+    const captureStdout: WriteFn = (chunk: string | Uint8Array): boolean => {
+      stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    };
+    process.stdout.write = captureStdout;
+  });
+
+  afterEach(() => {
+    process.stdout.write = originalStdoutWrite;
+  });
+
+  test("transitions the Issue itself to In Progress (not a separate PRD) before the queue runs", async () => {
+    const issue = makeStandaloneIssue({
+      id: "uuid-iss-7",
+      identifier: "ENG-7",
+    });
+    const transitionCalls: { ctx: LinearContext; issueId: string }[] = [];
+
+    await runQueueAfterPick({
+      picked: standaloneRoot(issue),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      // No children — the no-children validator must succeed.
+      fetchSubIssues: () => Promise.resolve([]),
+      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runPrTailStep: () =>
+        Promise.resolve({
+          outcome: { kind: "opened", url: "https://example/pr/1" },
+          outroMessage: "ok",
+          exitCode: 0,
+        } satisfies PrTailStepResult),
+      confirmRun: () => Promise.resolve(true),
+      confirmPr: () => Promise.resolve(true),
+      transitionRootToInProgress: (ctx, issueId) => {
+        transitionCalls.push({ ctx, issueId });
+        return Promise.resolve();
+      },
+    });
+
+    expect(transitionCalls).toHaveLength(1);
+    expect(transitionCalls[0]?.issueId).toBe("uuid-iss-7");
+  });
+
+  test("dispatches a one-element queue carrying the Standalone Issue itself", async () => {
+    const issue = makeStandaloneIssue({
+      id: "uuid-iss-7",
+      identifier: "ENG-7",
+      title: "Fix flaky export",
+    });
+    let capturedOrdered: { id: string; identifier: string; title: string }[] =
+      [];
+    let capturedRoot: { kind: string } | undefined;
+
+    await runQueueAfterPick({
+      picked: standaloneRoot(issue),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
+      runIssueQueue: (opts) => {
+        capturedOrdered = opts.orderedIssues;
+        capturedRoot = opts.root;
+        return Promise.resolve({ completed: 1, flipped: 0 });
+      },
+      runPrTailStep: () =>
+        Promise.resolve({
+          outcome: { kind: "opened", url: "https://example/pr/1" },
+          outroMessage: "ok",
+          exitCode: 0,
+        } satisfies PrTailStepResult),
+      confirmRun: () => Promise.resolve(true),
+      confirmPr: () => Promise.resolve(true),
+      transitionRootToInProgress: () => Promise.resolve(),
+    });
+
+    expect(capturedOrdered).toEqual([
+      { id: "uuid-iss-7", identifier: "ENG-7", title: "Fix flaky export" },
+    ]);
+    expect(capturedRoot).toEqual({ kind: "standalone" });
+  });
+
+  test("aborts on confirm when the Standalone Issue has Linear children, before any Linear write", async () => {
+    const issue = makeStandaloneIssue({ identifier: "ENG-7" });
+    let runIssueQueueCalls = 0;
+    let transitionCalls = 0;
+
+    const code = await runQueueAfterPick({
+      picked: standaloneRoot(issue),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () =>
+        Promise.resolve([
+          {
+            id: "uuid-child",
+            identifier: "ENG-77",
+            title: "Sub-task",
+            state: "Backlog",
+            stateType: "backlog",
+            labels: [],
+            blockedBy: [],
+          },
+        ] as SubIssue[]),
+      runIssueQueue: () => {
+        runIssueQueueCalls += 1;
+        return Promise.resolve({ completed: 0, flipped: 0 });
+      },
+      runPrTailStep: () =>
+        Promise.resolve({
+          outcome: { kind: "opted-out" },
+          outroMessage: "x",
+          exitCode: 0,
+        } satisfies PrTailStepResult),
+      confirmRun: () => Promise.resolve(true),
+      confirmPr: () => Promise.resolve(true),
+      transitionRootToInProgress: () => {
+        transitionCalls += 1;
+        return Promise.resolve();
+      },
+    });
+
+    expect(code).toBe(1);
+    expect(runIssueQueueCalls).toBe(0);
+    expect(transitionCalls).toBe(0);
+    const out = stdoutChunks.join("");
+    expect(out).toContain("ENG-7");
+    expect(out).toContain("Standalone Issue");
+    expect(out).toContain("non-PRD with children");
+  });
+
+  test("logs the BLOCKED warning when the standalone iteration ends on a flip (no completion)", async () => {
+    const issue = makeStandaloneIssue({ identifier: "ENG-7" });
+
+    const code = await runQueueAfterPick({
+      picked: standaloneRoot(issue),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
+      runIssueQueue: () => Promise.resolve({ completed: 0, flipped: 1 }),
+      runPrTailStep: () =>
+        Promise.resolve({
+          outcome: { kind: "opted-out" },
+          outroMessage: "Done. PR step skipped (you opted out at pre-flight).",
+          exitCode: 0,
+        } satisfies PrTailStepResult),
+      confirmRun: () => Promise.resolve(true),
+      confirmPr: () => Promise.resolve(false),
+      transitionRootToInProgress: () => Promise.resolve(),
+    });
+
+    expect(code).toBe(0);
+    const out = stdoutChunks.join("");
+    expect(out).toContain("Issue ENG-7 is flipped to `ready-for-human`");
+    // No-merge warning for "Issue" rather than "PRD".
+    expect(out).toContain("Issue ENG-7 will not auto-transition");
+  });
+
+  test("pre-flight summary text branches per root kind: 'Standalone Issue: 1 iteration'", async () => {
+    const issue = makeStandaloneIssue({ identifier: "ENG-7" });
+
+    await runQueueAfterPick({
+      picked: standaloneRoot(issue),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
+      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runPrTailStep: () =>
+        Promise.resolve({
+          outcome: { kind: "opened", url: "https://example/pr/1" },
+          outroMessage: "ok",
+          exitCode: 0,
+        } satisfies PrTailStepResult),
+      confirmRun: () => Promise.resolve(true),
+      confirmPr: () => Promise.resolve(true),
+      transitionRootToInProgress: () => Promise.resolve(),
+    });
+
+    const out = stdoutChunks.join("");
+    expect(out).toContain("Standalone Issue: 1 iteration");
+    // PRD-rooted summary text must not appear.
+    expect(out).not.toContain("PRD-rooted:");
+  });
+
+  test("PR-tail receives an empty subIssues list (the body's `Sub-issues addressed` block is omitted by buildPrPromptArgs)", async () => {
+    const issue = makeStandaloneIssue({ identifier: "ENG-7" });
+    let capturedSubIssues: { number: number; title: string }[] | undefined;
+
+    await runQueueAfterPick({
+      picked: standaloneRoot(issue),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
+      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runPrTailStep: (opts) => {
+        capturedSubIssues = opts.subIssues;
+        return Promise.resolve({
+          outcome: { kind: "opened", url: "https://example/pr/1" },
+          outroMessage: "ok",
+          exitCode: 0,
+        } satisfies PrTailStepResult);
+      },
+      confirmRun: () => Promise.resolve(true),
+      confirmPr: () => Promise.resolve(true),
+      transitionRootToInProgress: () => Promise.resolve(),
+    });
+
+    expect(capturedSubIssues).toEqual([]);
   });
 });

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -3,17 +3,22 @@
 // Steps:
 //   1. discover repo root → capture base branch (fail fast on detached HEAD)
 //      → load config + env → resolve gh identity + token → build sandbox image
-//   2. fetch the team's PRDs from Linear (filter: prd + ready-for-agent
-//      labels, non-terminal state.type) and clack-select a PRD
-//   3. fetch the picked PRD's direct sub-issues from Linear, build the
-//      ordered queue (filter to `ready-for-agent`, topo-sort by `blockedBy`,
-//      or fall back to a one-iteration standalone path)
-//   4. preflight summary + Y/n confirms, then run the queue
+//   2. fetch the team's PRDs and Standalone Issues from Linear in parallel
+//      (PRDs: `prd` label + at least one `ready-for-agent` direct child;
+//      Standalone Issues: `ready-for-agent` label, no parent, no `prd`),
+//      then clack-select a single root
+//   3. dispatch on root kind:
+//        - PRD root: fetch the picked PRD's direct sub-issues, build the
+//          topo-ordered queue (filter to `ready-for-agent`)
+//        - Standalone Issue root: validate no Linear children exist, then
+//          build a one-element queue from the issue itself
+//   4. preflight summary + Y/n confirms, transition the root to *In
+//      Progress*, then run the queue
 //   5. push the feature branch and open a PR (or skip cleanly)
 //
-// No Linear writes happen from the host yet — sub-issues stay in their
-// original workflow state throughout. State transitions and the summarizer
-// are introduced in later slices.
+// All Linear writes happen from the host (ADR-0005). The branch name is
+// the sole PR↔root link — Linear's GitHub integration auto-transitions
+// the root on merge (ADR-0006).
 
 import { existsSync, lstatSync, mkdirSync, symlinkSync } from "node:fs";
 import path from "node:path";
@@ -43,9 +48,11 @@ import type { GhRepo } from "../github/index.ts";
 import {
   fetchSubIssues as defaultFetchSubIssues,
   listPRDs as defaultListPRDs,
+  listStandaloneIssues as defaultListStandaloneIssues,
   transitionToInProgress as defaultTransitionToInProgress,
   type LinearContext,
   type PRD,
+  type StandaloneIssue,
   type SubIssue,
 } from "../linear/index.ts";
 import {
@@ -64,7 +71,10 @@ import {
   type RunIssueQueueOptions,
   type RunIssueQueueResult,
 } from "../runner/index.ts";
-import { pickPRD as defaultPickPRD } from "../selector/index.ts";
+import {
+  pickRoot as defaultPickRoot,
+  type RootRef,
+} from "../selector/index.ts";
 
 const READY_FOR_AGENT = "ready-for-agent";
 const READY_FOR_HUMAN = "ready-for-human";
@@ -83,8 +93,13 @@ export interface RunOptions {
   getGhToken?: (options: GetGhTokenOptions) => Promise<string>;
   /** Linear PRD list fetcher. Tests stub this to avoid hitting Linear. */
   listPRDs?: (ctx: LinearContext) => Promise<PRD[]>;
-  /** PRD selector prompt. Tests stub this to bypass the clack UI. */
-  pickPRD?: (prds: readonly PRD[]) => Promise<PRD>;
+  /** Linear Standalone Issue list fetcher. Tests stub this. */
+  listStandaloneIssues?: (ctx: LinearContext) => Promise<StandaloneIssue[]>;
+  /** Root selector prompt. Tests stub this to bypass the clack UI. */
+  pickRoot?: (input: {
+    prds: readonly PRD[];
+    standaloneIssues: readonly StandaloneIssue[];
+  }) => Promise<RootRef>;
   /**
    * Test seam: post-pick orchestration (queue build + confirms + queue run +
    * PR tail). Defaults to the in-module `runQueueAfterPick`.
@@ -99,15 +114,18 @@ export interface RunOptions {
 }
 
 export interface RunQueueAfterPickOptions {
-  picked: PRD;
+  /** Tagged-union root reference returned by the picker. */
+  picked: RootRef;
   ghRepo: GhRepo;
   baseBranch: string;
   linearCtx: LinearContext;
   repoRoot: string;
   config: TideConfig;
   sandboxEnv: Record<string, string>;
-  /** Test seam — defaults to `linear.fetchSubIssues`. */
-  fetchSubIssues?: (ctx: LinearContext, prdId: string) => Promise<SubIssue[]>;
+  /** Test seam — defaults to `linear.fetchSubIssues`. Used both to build
+   * the queue for PRD roots and to validate the "no children" rule for
+   * Standalone Issue roots. */
+  fetchSubIssues?: (ctx: LinearContext, issueId: string) => Promise<SubIssue[]>;
   /** Test seam — defaults to the runner module's `runIssueQueue`. */
   runIssueQueue?: (opts: RunIssueQueueOptions) => Promise<RunIssueQueueResult>;
   /** Test seam — defaults to the in-module `runPrTailStep`. */
@@ -117,9 +135,10 @@ export interface RunQueueAfterPickOptions {
   /** Test seam — clack `confirm` for "Create a PR at the end?". */
   confirmPr?: () => Promise<boolean>;
   /** Test seam — defaults to `linear.transitionToInProgress`. Used to
-   * transition the PRD itself to *In Progress* once both pre-flight confirms
-   * have been answered. */
-  transitionPrdToInProgress?: (
+   * transition the picked root to *In Progress* once both pre-flight
+   * confirms have been answered. For PRD roots this is the PRD itself; for
+   * Standalone Issue roots this is the issue itself. */
+  transitionRootToInProgress?: (
     ctx: LinearContext,
     issueId: string
   ) => Promise<void>;
@@ -130,12 +149,14 @@ export interface RunPrTailStepOptions {
   ghRepo: GhRepo;
   branch: string;
   baseBranch: string;
-  /** Linear PRD identifier (e.g. "MEC-123"). */
-  parentIdentifier: string;
-  parentTitle: string;
-  /** Linear PRD URL. */
-  parentUrl: string;
-  /** Topo-ordered sub-issues addressed by this PR. */
+  /** Linear root identifier (e.g. "MEC-123"). PRD identifier for PRD
+   * roots; Standalone Issue identifier for Standalone roots. */
+  rootIdentifier: string;
+  rootTitle: string;
+  /** Linear root URL. */
+  rootUrl: string;
+  /** Topo-ordered sub-issues addressed by this PR. Empty for Standalone
+   * Issue roots. */
   subIssues: SubIssueRef[];
   repoRoot: string;
   config: TideConfig;
@@ -323,9 +344,9 @@ export async function runPrTailStep(
       ghRepo: opts.ghRepo,
       branch: opts.branch,
       baseBranch: opts.baseBranch,
-      parentIdentifier: opts.parentIdentifier,
-      parentTitle: opts.parentTitle,
-      parentUrl: opts.parentUrl,
+      rootIdentifier: opts.rootIdentifier,
+      rootTitle: opts.rootTitle,
+      rootUrl: opts.rootUrl,
       subIssues: opts.subIssues,
       repoRoot: opts.repoRoot,
       config: opts.config,
@@ -366,11 +387,40 @@ async function defaultConfirmPr(): Promise<boolean> {
   return !isCancel(answer) && answer;
 }
 
+interface RootMeta {
+  /** Linear UUID of the picked root. */
+  id: string;
+  identifier: string;
+  title: string;
+  branchName: string;
+  url: string;
+}
+
+function rootMetaFromPicked(picked: RootRef): RootMeta {
+  if (picked.kind === "prd") {
+    return {
+      id: picked.prd.id,
+      identifier: picked.prd.identifier,
+      title: picked.prd.title,
+      branchName: picked.prd.branchName,
+      url: picked.prd.url,
+    };
+  }
+  return {
+    id: picked.issue.id,
+    identifier: picked.issue.identifier,
+    title: picked.issue.title,
+    branchName: picked.issue.branchName,
+    url: picked.issue.url,
+  };
+}
+
 /**
- * Post-pick orchestration: fetch sub-issues, build the queue, run pre-flight
- * confirms, run the queue, and dispatch to `runPrTailStep` for the PR step.
- * Surfaced as a named export so tests can stub it for early-gate coverage
- * and exercise it directly with stubs for orchestration coverage.
+ * Post-pick orchestration: fetch sub-issues (PRD root) or validate
+ * structure (Standalone Issue root), build the queue, run pre-flight
+ * confirms, run the queue, and dispatch to `runPrTailStep` for the PR
+ * step. Surfaced as a named export so tests can stub it for early-gate
+ * coverage and exercise it directly with stubs for orchestration coverage.
  */
 export async function runQueueAfterPick(
   opts: RunQueueAfterPickOptions
@@ -380,15 +430,18 @@ export async function runQueueAfterPick(
   const runPrTailStepFn = opts.runPrTailStep ?? runPrTailStep;
   const confirmRunFn = opts.confirmRun ?? defaultConfirmRun;
   const confirmPrFn = opts.confirmPr ?? defaultConfirmPr;
-  const transitionPrdToInProgressFn =
-    opts.transitionPrdToInProgress ?? defaultTransitionToInProgress;
+  const transitionRootToInProgressFn =
+    opts.transitionRootToInProgress ?? defaultTransitionToInProgress;
 
-  // Pre-flight: refuse to run from the picked PRD's feature branch. The base
-  // branch we resolved at startup is whatever the user invoked `tide run`
-  // from; if it matches the PRD's auto-generated `branchName`, the user has
-  // already checked out the feature branch and would otherwise stack the new
-  // PR on top of itself. Fail before any Linear write or sandbox launch.
-  if (opts.picked.branchName === opts.baseBranch) {
+  const root = rootMetaFromPicked(opts.picked);
+
+  // Pre-flight: refuse to run from the picked root's feature branch. The
+  // base branch we resolved at startup is whatever the user invoked `tide
+  // run` from; if it matches the root's auto-generated `branchName`, the
+  // user has already checked out the feature branch and would otherwise
+  // stack the new PR on top of itself. Fail before any Linear write or
+  // sandbox launch.
+  if (root.branchName === opts.baseBranch) {
     log.error(
       `tide run must be invoked from the base branch, not the feature branch (${opts.baseBranch}). Switch back to your base branch and re-run.`
     );
@@ -396,62 +449,91 @@ export async function runQueueAfterPick(
     return 1;
   }
 
-  const subSpin = spinner();
-  subSpin.start("Fetching sub-issues from Linear");
-  let subIssues: SubIssue[];
-  try {
-    subIssues = await fetchSubIssuesFn(opts.linearCtx, opts.picked.id);
-  } catch (err) {
-    subSpin.stop("Linear sub-issue fetch failed");
-    const msg = err instanceof Error ? err.message : String(err);
-    log.error(msg);
-    outro("Aborted.");
-    return 1;
-  }
-  subSpin.stop(`Fetched ${String(subIssues.length)} sub-issue(s)`);
+  let orderedIssues: OrderedIssue[];
 
-  const queue = buildOrderedQueue(subIssues);
-  if (queue.kind === "error") {
-    log.error(queue.message);
-    outro("Aborted.");
-    return 1;
-  }
+  if (opts.picked.kind === "prd") {
+    const subSpin = spinner();
+    subSpin.start("Fetching sub-issues from Linear");
+    let subIssues: SubIssue[];
+    try {
+      subIssues = await fetchSubIssuesFn(opts.linearCtx, root.id);
+    } catch (err) {
+      subSpin.stop("Linear sub-issue fetch failed");
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(msg);
+      outro("Aborted.");
+      return 1;
+    }
+    subSpin.stop(`Fetched ${String(subIssues.length)} sub-issue(s)`);
 
-  const branch = opts.picked.branchName;
-  const orderedIssues: OrderedIssue[] =
-    queue.kind === "standalone"
-      ? [
-          {
-            id: opts.picked.id,
-            identifier: opts.picked.identifier,
-            title: opts.picked.title,
-          },
-        ]
-      : queue.ordered;
+    const queue = buildOrderedQueue(subIssues);
+    if (queue.kind === "error") {
+      log.error(queue.message);
+      outro("Aborted.");
+      return 1;
+    }
+    orderedIssues =
+      queue.kind === "standalone"
+        ? [{ id: root.id, identifier: root.identifier, title: root.title }]
+        : queue.ordered;
 
-  log.info(`Branch: ${branch}`);
-  if (queue.kind === "standalone") {
-    log.info(
-      "Standalone PRD (no `ready-for-agent` direct children) — running the PRD itself."
-    );
+    log.info(`Branch: ${root.branchName}`);
+    if (queue.kind === "standalone") {
+      log.info(
+        "Standalone PRD (no `ready-for-agent` direct children) — running the PRD itself."
+      );
+    } else {
+      log.info(
+        `PRD-rooted: ${String(queue.ordered.length)} sub-issue(s) in topo order:`
+      );
+      for (const o of queue.ordered) {
+        log.message(`  ${o.identifier} ${o.title}`);
+      }
+    }
+
+    // Surface direct children flagged `ready-for-human` (typically the
+    // residue of a previous run's BLOCKED / agent-FAIL flip) as a one-line
+    // skip notice so the user knows what is *not* in the queue. These are
+    // already excluded from `queue.ordered` by `buildOrderedQueue`.
+    for (const s of subIssues) {
+      if (s.labels.includes(READY_FOR_HUMAN)) {
+        log.info(`Skipping ${s.identifier}: ready-for-human`);
+      }
+    }
   } else {
-    log.info("Topo-ordered queue:");
-    for (const o of queue.ordered) {
-      log.message(`  ${o.identifier} ${o.title}`);
+    // Standalone Issue root: validate the no-children contract before any
+    // Linear write. Misconfigured "ready-for-agent" issues with sub-tasks
+    // get a teaching-moment error instead of a silent half-run.
+    const childSpin = spinner();
+    childSpin.start("Verifying Standalone Issue has no Linear children");
+    let children: SubIssue[];
+    try {
+      children = await fetchSubIssuesFn(opts.linearCtx, root.id);
+    } catch (err) {
+      childSpin.stop("Linear child fetch failed");
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(msg);
+      outro("Aborted.");
+      return 1;
     }
+    childSpin.stop("Verified");
+    if (children.length > 0) {
+      log.error(
+        `${root.identifier} is a Standalone Issue but has ${String(children.length)} Linear ` +
+          "child issue(s) — non-PRD with children. Label the parent as `prd` or remove the children, then re-run."
+      );
+      outro("Aborted.");
+      return 1;
+    }
+
+    orderedIssues = [
+      { id: root.id, identifier: root.identifier, title: root.title },
+    ];
+    log.info(`Branch: ${root.branchName}`);
+    log.info(`Standalone Issue: 1 iteration on ${root.identifier}.`);
   }
 
-  // Surface direct children flagged `ready-for-human` (typically the
-  // residue of a previous run's BLOCKED / agent-FAIL flip) as a one-line
-  // skip notice so the user knows what is *not* in the queue. These are
-  // already excluded from `queue.ordered` by `buildOrderedQueue`.
-  for (const s of subIssues) {
-    if (s.labels.includes(READY_FOR_HUMAN)) {
-      log.info(`Skipping ${s.identifier}: ready-for-human`);
-    }
-  }
-
-  const proceed = await confirmRunFn(orderedIssues.length, branch);
+  const proceed = await confirmRunFn(orderedIssues.length, root.branchName);
   if (!proceed) {
     cancel("Cancelled before any run() invocation.");
     return 0;
@@ -459,24 +541,27 @@ export async function runQueueAfterPick(
 
   const prCreationConfirmed = await confirmPrFn();
 
-  // Transition the PRD itself to *In Progress* once the user has committed
-  // to running the queue. A cancelled pre-flight (above) leaves the PRD
+  // Transition the picked root to *In Progress* once the user has committed
+  // to running the queue. A cancelled pre-flight (above) leaves it
   // untouched. A failure here is an infra failure — no Linear writes have
-  // happened on sub-issues yet, so we abort cleanly.
+  // happened on iteration units yet, so we abort cleanly.
   try {
-    await transitionPrdToInProgressFn(opts.linearCtx, opts.picked.id);
+    await transitionRootToInProgressFn(opts.linearCtx, root.id);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    log.error(`Failed to transition PRD to In Progress: ${msg}`);
+    const label = opts.picked.kind === "prd" ? "PRD" : "Issue";
+    log.error(`Failed to transition ${label} to In Progress: ${msg}`);
     outro("Aborted.");
     return 1;
   }
 
   const queueResult = await runIssueQueueFn({
-    parentIdentifier: opts.picked.identifier,
-    parentId: opts.picked.id,
+    root:
+      opts.picked.kind === "prd"
+        ? { kind: "prd", id: root.id, identifier: root.identifier }
+        : { kind: "standalone" },
     orderedIssues,
-    branch,
+    branch: root.branchName,
     baseBranch: opts.baseBranch,
     linearCtx: opts.linearCtx,
     repoRoot: opts.repoRoot,
@@ -493,27 +578,30 @@ export async function runQueueAfterPick(
     log.info(
       `Completed ${String(queueResult.completed)} of ${String(orderedIssues.length)} issue(s) before abort.`
     );
-    outro("Aborted. Inspect the worktree, fix, and re-run on the same PRD.");
+    outro("Aborted. Inspect the worktree, fix, and re-run on the same root.");
     return 1;
   }
 
-  // Convert ordered queue into the PR-tail's SubIssueRef shape. The PR-tail
-  // is an in-flight legacy seam keyed on numeric issue numbers; for the
-  // Linear-native flow we surface identifier strings via the title to
-  // preserve the existing template's "Sub-issues addressed" list.
-  const subIssueRefs: SubIssueRef[] = orderedIssues.map((o, i) => ({
-    number: i + 1,
-    title: `${o.identifier} ${o.title}`,
-  }));
+  // Convert ordered queue into the PR-tail's SubIssueRef shape. For PRD
+  // roots we surface the topo-ordered sub-issues as numbered bullets so the
+  // template renders the "Sub-issues addressed" block. For Standalone Issue
+  // roots we pass an empty list — the block is omitted entirely.
+  const subIssueRefs: SubIssueRef[] =
+    opts.picked.kind === "prd"
+      ? orderedIssues.map((o, i) => ({
+          number: i + 1,
+          title: `${o.identifier} ${o.title}`,
+        }))
+      : [];
 
   const tail = await runPrTailStepFn({
     prCreationConfirmed,
     ghRepo: opts.ghRepo,
-    branch,
+    branch: root.branchName,
     baseBranch: opts.baseBranch,
-    parentIdentifier: opts.picked.identifier,
-    parentTitle: opts.picked.title,
-    parentUrl: opts.picked.url,
+    rootIdentifier: root.identifier,
+    rootTitle: root.title,
+    rootUrl: root.url,
     subIssues: subIssueRefs,
     repoRoot: opts.repoRoot,
     config: opts.config,
@@ -527,13 +615,28 @@ export async function runQueueAfterPick(
     log.success(tail.outcome.url);
   }
 
+  // Standalone-Issue end-of-run BLOCKED warning: when no commits landed on
+  // the iteration the issue is now flipped to `ready-for-human` and stays
+  // *In Progress* until the user resolves it. Fire alongside the no-merge
+  // warning below.
+  if (
+    opts.picked.kind === "standalone" &&
+    queueResult.completed === 0 &&
+    queueResult.flipped > 0
+  ) {
+    log.warn(
+      `Issue ${root.identifier} is flipped to \`ready-for-human\` and stays *In Progress* until you resolve it.`
+    );
+  }
+
   // No-merge warning: any tail outcome other than `opened` means no PR was
   // opened on this run, so Linear's GitHub integration won't auto-transition
-  // the PRD to Done on merge. Surface this as a yellow warning so the user
-  // can transition the PRD manually if they're shipping outside this run.
+  // the root to Done on merge. Surface this as a yellow warning so the user
+  // can transition manually if they're shipping outside this run.
   if (tail.outcome.kind !== "opened") {
+    const label = opts.picked.kind === "prd" ? "PRD" : "Issue";
     log.warn(
-      `PRD ${opts.picked.identifier} will not auto-transition. Transition manually in Linear if shipping outside this run.`
+      `${label} ${root.identifier} will not auto-transition. Transition manually in Linear if shipping outside this run.`
     );
   }
 
@@ -577,7 +680,9 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
   const getGhIdentity = options.getGhIdentity ?? defaultGetGhIdentity;
   const getGhToken = options.getGhToken ?? defaultGetGhToken;
   const listPRDsFn = options.listPRDs ?? defaultListPRDs;
-  const pickPRDFn = options.pickPRD ?? defaultPickPRD;
+  const listStandaloneIssuesFn =
+    options.listStandaloneIssues ?? defaultListStandaloneIssues;
+  const pickRootFn = options.pickRoot ?? defaultPickRoot;
   const runQueueAfterPickFn = options.runQueueAfterPick ?? runQueueAfterPick;
 
   let repoRoot: string;
@@ -673,39 +778,52 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
 
   intro("tide run");
 
-  // Fetch the PRD list from Linear.
+  // Fetch PRDs and Standalone Issues in parallel.
   const fetchSpin = spinner();
-  fetchSpin.start("Fetching PRDs from Linear");
+  fetchSpin.start("Fetching PRDs and Standalone Issues from Linear");
+  const linearCtx: LinearContext = {
+    apiKey: linearApiKey,
+    teamKey: config.linear.team,
+  };
   let prds: PRD[];
+  let standaloneIssues: StandaloneIssue[];
   try {
-    prds = await listPRDsFn({
-      apiKey: linearApiKey,
-      teamKey: config.linear.team,
-    });
+    [prds, standaloneIssues] = await Promise.all([
+      listPRDsFn(linearCtx),
+      listStandaloneIssuesFn(linearCtx),
+    ]);
   } catch (err) {
     fetchSpin.stop("Linear fetch failed");
     const msg = err instanceof Error ? err.message : String(err);
     stderr(`${msg}\n`);
     return 1;
   }
-  fetchSpin.stop(`Fetched ${String(prds.length)} PRD(s)`);
+  fetchSpin.stop(
+    `Fetched ${String(prds.length)} PRD(s), ${String(standaloneIssues.length)} Standalone Issue(s)`
+  );
 
-  if (prds.length === 0) {
+  if (prds.length === 0 && standaloneIssues.length === 0) {
     outro(
-      "No PRDs to run. Author one in Linear with the `prd` + `ready-for-agent` labels."
+      "No roots to run. Author a PRD with `ready-for-agent` sub-issues, or a Standalone Issue with the `ready-for-agent` label, in Linear."
     );
     return 0;
   }
 
-  const picked = await pickPRDFn(prds);
+  const picked = await pickRootFn({ prds, standaloneIssues });
 
-  log.info(`Selected: ${picked.identifier} ${picked.title}`);
+  if (picked.kind === "prd") {
+    log.info(`Selected: [PRD] ${picked.prd.identifier} ${picked.prd.title}`);
+  } else {
+    log.info(
+      `Selected: [Issue] ${picked.issue.identifier} ${picked.issue.title}`
+    );
+  }
 
   return await runQueueAfterPickFn({
     picked,
     ghRepo: { owner: ghIdentity.owner, repo: ghIdentity.repo },
     baseBranch,
-    linearCtx: { apiKey: linearApiKey, teamKey: config.linear.team },
+    linearCtx,
     repoRoot,
     config,
     sandboxEnv,

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -501,9 +501,27 @@ export async function runQueueAfterPick(
       }
     }
   } else {
-    // Standalone Issue root: validate the no-children contract before any
-    // Linear write. Misconfigured "ready-for-agent" issues with sub-tasks
-    // get a teaching-moment error instead of a silent half-run.
+    // Standalone Issue root: build a one-element queue. The no-children
+    // contract is validated post-confirm (below) so that a user who cancels
+    // out of the pre-flight does not see a structural error message.
+    orderedIssues = [
+      { id: root.id, identifier: root.identifier, title: root.title },
+    ];
+    log.info(`Branch: ${root.branchName}`);
+    log.info(`Standalone Issue: 1 iteration on ${root.identifier}.`);
+  }
+
+  const proceed = await confirmRunFn(orderedIssues.length, root.branchName);
+  if (!proceed) {
+    cancel("Cancelled before any run() invocation.");
+    return 0;
+  }
+
+  // Standalone Issue contract: no Linear children. Validated only after the
+  // user has confirmed the pre-flight, so a cancel at the confirm prompt
+  // does not surface this structural error. No Linear writes have happened
+  // yet, so the abort path stays clean.
+  if (opts.picked.kind === "standalone") {
     const childSpin = spinner();
     childSpin.start("Verifying Standalone Issue has no Linear children");
     let children: SubIssue[];
@@ -525,18 +543,6 @@ export async function runQueueAfterPick(
       outro("Aborted.");
       return 1;
     }
-
-    orderedIssues = [
-      { id: root.id, identifier: root.identifier, title: root.title },
-    ];
-    log.info(`Branch: ${root.branchName}`);
-    log.info(`Standalone Issue: 1 iteration on ${root.identifier}.`);
-  }
-
-  const proceed = await confirmRunFn(orderedIssues.length, root.branchName);
-  if (!proceed) {
-    cancel("Cancelled before any run() invocation.");
-    return 0;
   }
 
   const prCreationConfirmed = await confirmPrFn();

--- a/src/linear/index.test.ts
+++ b/src/linear/index.test.ts
@@ -6,6 +6,7 @@ import {
   fetchSubIssues,
   flipLabelToReadyForHuman,
   listPRDs,
+  listStandaloneIssues,
   pickWorkflowStateByType,
   postComment,
   setupLabels,
@@ -15,6 +16,8 @@ import {
   type LinearGqlRequest,
   type ListPRDsClient,
   type ListPRDsIssueFilter,
+  type ListStandaloneIssuesClient,
+  type ListStandaloneIssuesFilter,
   type SetupLabelsClient,
 } from "./index.ts";
 
@@ -286,7 +289,7 @@ function buildListPRDsStub(options: ListPRDsStubOptions = {}): ListPRDsStub {
 }
 
 describe("linear.listPRDs", () => {
-  test("queries with prd + ready-for-agent labels and non-terminal state.type", async () => {
+  test("queries with the prd label and non-terminal state.type (no ready-for-agent gate on the PRD itself)", async () => {
     const stub = buildListPRDsStub({
       prdNodes: [],
       states: [],
@@ -303,13 +306,16 @@ describe("linear.listPRDs", () => {
     // Team filter pinned.
     expect(filter.team?.id.eq).toBe("team-ENG");
 
-    // Both labels required (compound AND, so issues must carry both).
+    // Only the `prd` label is required on the PRD itself. PRDs no longer
+    // carry `ready-for-agent` directly under the new flow — that label
+    // marks an entry-point unit of work (a PRD's sub-issue or a Standalone
+    // Issue), not a planning unit.
     expect(filter.and).toBeDefined();
     const labelClauses = (filter.and ?? [])
       .map((c) => c.labels?.name.eq)
       .filter((n): n is string => typeof n === "string")
       .sort();
-    expect(labelClauses).toEqual(["prd", "ready-for-agent"]);
+    expect(labelClauses).toEqual(["prd"]);
 
     // Non-terminal state.type filter applied.
     const stateTypes = filter.state?.type.in;
@@ -320,6 +326,41 @@ describe("linear.listPRDs", () => {
 
     // Ordered by updatedAt desc.
     expect(stub.issuesOrderBys[0]).toBe(PaginationOrderBy.UpdatedAt);
+  });
+
+  test("excludes PRDs with zero `ready-for-agent` direct children (Standalone PRDs)", async () => {
+    // A `prd`-labeled issue with no triaged sub-issues yet is a "Standalone
+    // PRD" and must not appear in the picker.
+    const stub = buildListPRDsStub({
+      prdNodes: [
+        {
+          id: "issue-with-children",
+          identifier: "ENG-1",
+          title: "Has triaged work",
+          stateId: undefined,
+          branchName: "b",
+          url: "u",
+          updatedAt: new Date(0),
+        },
+        {
+          id: "issue-pre-triage",
+          identifier: "ENG-2",
+          title: "Standalone PRD",
+          stateId: undefined,
+          branchName: "b",
+          url: "u",
+          updatedAt: new Date(0),
+        },
+      ],
+      childCountsByParent: {
+        "issue-with-children": { "ready-for-agent": 2, "ready-for-human": 0 },
+        "issue-pre-triage": { "ready-for-agent": 0, "ready-for-human": 0 },
+      },
+    });
+
+    const prds = await listPRDs(ctx, stub.client);
+
+    expect(prds.map((p) => p.identifier)).toEqual(["ENG-1"]);
   });
 
   test("returns each PRD with sub-issue counts split by ready-for-agent / ready-for-human", async () => {
@@ -355,7 +396,7 @@ describe("linear.listPRDs", () => {
       ],
       childCountsByParent: {
         "issue-1": { "ready-for-agent": 3, "ready-for-human": 1 },
-        "issue-2": { "ready-for-agent": 0, "ready-for-human": 2 },
+        "issue-2": { "ready-for-agent": 2, "ready-for-human": 2 },
       },
     });
 
@@ -377,7 +418,7 @@ describe("linear.listPRDs", () => {
 
     expect(b.identifier).toBe("ENG-2");
     expect(b.state).toBe("Backlog");
-    expect(b.readyForAgentCount).toBe(0);
+    expect(b.readyForAgentCount).toBe(2);
     expect(b.readyForHumanCount).toBe(2);
   });
 
@@ -446,10 +487,171 @@ describe("linear.listPRDs", () => {
         },
       ],
       states: [],
-      childCountsByParent: { "issue-x": {} },
+      childCountsByParent: { "issue-x": { "ready-for-agent": 1 } },
     });
     const prds = await listPRDs(ctx, stub.client);
     expect(prds[0]?.state).toBe("");
+  });
+});
+
+interface ListStandaloneStubOptions {
+  knownTeamKeys?: readonly string[];
+  issueNodes?: {
+    id: string;
+    identifier: string;
+    title: string;
+    stateId: string | undefined;
+    branchName: string;
+    url: string;
+    updatedAt: Date;
+  }[];
+  states?: { id: string; name: string; type: string; position: number }[];
+}
+
+interface ListStandaloneStub {
+  client: ListStandaloneIssuesClient;
+  issuesFilters: ListStandaloneIssuesFilter[];
+  issuesOrderBys: (PaginationOrderBy | undefined)[];
+}
+
+function buildListStandaloneStub(
+  options: ListStandaloneStubOptions = {}
+): ListStandaloneStub {
+  const knownTeamKeys = options.knownTeamKeys ?? ["ENG"];
+  const issuesFilters: ListStandaloneIssuesFilter[] = [];
+  const issuesOrderBys: (PaginationOrderBy | undefined)[] = [];
+
+  const client: ListStandaloneIssuesClient = {
+    teams: ({ filter }) => {
+      const key = filter.key.eq;
+      if (!knownTeamKeys.includes(key)) {
+        return Promise.resolve({ nodes: [] });
+      }
+      return Promise.resolve({ nodes: [{ id: `team-${key}` }] });
+    },
+    workflowStates: () => Promise.resolve({ nodes: options.states ?? [] }),
+    issues: ({ filter, orderBy }) => {
+      issuesFilters.push(filter);
+      issuesOrderBys.push(orderBy);
+      return Promise.resolve({ nodes: options.issueNodes ?? [] });
+    },
+  };
+
+  return { client, issuesFilters, issuesOrderBys };
+}
+
+describe("linear.listStandaloneIssues", () => {
+  test("queries for ready-for-agent issues with no parent and no `prd` label, in non-terminal states", async () => {
+    const stub = buildListStandaloneStub();
+
+    await listStandaloneIssues(ctx, stub.client);
+
+    const filter = stub.issuesFilters[0];
+    expect(filter).toBeDefined();
+    if (!filter) throw new Error("expected one issues call");
+
+    expect(filter.team?.id.eq).toBe("team-ENG");
+
+    // Standalone Issues have no Linear parent.
+    expect(filter.parent?.null).toBe(true);
+
+    // Non-terminal state.type filter applied (matches listPRDs).
+    const stateTypes = filter.state?.type.in;
+    expect(stateTypes).toBeDefined();
+    if (!stateTypes) throw new Error("expected state.type.in");
+    expect([...stateTypes].sort()).toEqual([
+      "backlog",
+      "started",
+      "triage",
+      "unstarted",
+    ]);
+
+    // Two label clauses: requires ready-for-agent (some), forbids prd
+    // (every).
+    expect(filter.and).toBeDefined();
+    const someClauses = (filter.and ?? [])
+      .map((c) =>
+        c.labels && "some" in c.labels ? c.labels.some.name.eq : undefined
+      )
+      .filter((n): n is string => typeof n === "string");
+    const everyClauses = (filter.and ?? [])
+      .map((c) =>
+        c.labels && "every" in c.labels ? c.labels.every.name.neq : undefined
+      )
+      .filter((n): n is string => typeof n === "string");
+    expect(someClauses).toEqual(["ready-for-agent"]);
+    expect(everyClauses).toEqual(["prd"]);
+
+    // Ordered by updatedAt desc.
+    expect(stub.issuesOrderBys[0]).toBe(PaginationOrderBy.UpdatedAt);
+  });
+
+  test("returns each issue with identifier, title, state, branchName, url", async () => {
+    const stub = buildListStandaloneStub({
+      issueNodes: [
+        {
+          id: "issue-1",
+          identifier: "ENG-7",
+          title: "Fix flaky export",
+          stateId: "state-backlog",
+          branchName: "user/eng-7-fix-flaky-export",
+          url: "https://linear.app/eng/issue/ENG-7",
+          updatedAt: new Date("2026-04-10T00:00:00Z"),
+        },
+      ],
+      states: [
+        { id: "state-backlog", name: "Backlog", type: "backlog", position: 0 },
+      ],
+    });
+
+    const issues = await listStandaloneIssues(ctx, stub.client);
+
+    expect(issues).toHaveLength(1);
+    const a = issues[0];
+    if (!a) throw new Error("unreachable");
+    expect(a.id).toBe("issue-1");
+    expect(a.identifier).toBe("ENG-7");
+    expect(a.title).toBe("Fix flaky export");
+    expect(a.state).toBe("Backlog");
+    expect(a.branchName).toBe("user/eng-7-fix-flaky-export");
+    expect(a.url).toBe("https://linear.app/eng/issue/ENG-7");
+  });
+
+  test("returns an empty list when no issues match", async () => {
+    const stub = buildListStandaloneStub({ issueNodes: [] });
+    const issues = await listStandaloneIssues(ctx, stub.client);
+    expect(issues).toEqual([]);
+  });
+
+  test("falls back to empty state name when stateId does not resolve", async () => {
+    const stub = buildListStandaloneStub({
+      issueNodes: [
+        {
+          id: "issue-1",
+          identifier: "ENG-7",
+          title: "x",
+          stateId: "missing-state",
+          branchName: "b",
+          url: "u",
+          updatedAt: new Date(0),
+        },
+      ],
+      states: [],
+    });
+    const issues = await listStandaloneIssues(ctx, stub.client);
+    expect(issues[0]?.state).toBe("");
+  });
+
+  test("throws when the configured team key does not exist", async () => {
+    const stub = buildListStandaloneStub({ knownTeamKeys: ["OTHER"] });
+    let caught: unknown = null;
+    try {
+      await listStandaloneIssues(ctx, stub.client);
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    expect((caught as Error).message).toMatch(/team with key "ENG" not found/);
   });
 });
 

--- a/src/linear/index.ts
+++ b/src/linear/index.ts
@@ -1,8 +1,12 @@
 // Linear SDK facade for the Linear-native flow. Operations:
 //   - listPRDs(ctx): list every issue on the configured team that carries
-//     both `prd` and `ready-for-agent` labels and is in a non-terminal
-//     workflow state. Each entry carries the count of its direct sub-issues
-//     split by `ready-for-agent` / `ready-for-human` label.
+//     the `prd` label and has at least one direct sub-issue carrying
+//     `ready-for-agent`, in a non-terminal workflow state. Each entry
+//     carries the count of its direct sub-issues split by
+//     `ready-for-agent` / `ready-for-human` label.
+//   - listStandaloneIssues(ctx): list every issue on the configured team
+//     that carries `ready-for-agent`, has no Linear parent, and does not
+//     carry the `prd` label, in a non-terminal workflow state.
 //   - fetchSubIssues(ctx, prdId): direct Linear children of a given PRD, with
 //     identifier, title, workflow state, label set, and blockedBy relations.
 //   - fetchIssueContent(ctx, issueId): the issue's description (markdown
@@ -72,6 +76,18 @@ export interface PRD {
   readyForHumanCount: number;
 }
 
+export interface StandaloneIssue {
+  /** Linear's internal UUID. */
+  id: string;
+  identifier: string;
+  title: string;
+  /** Workflow-state name (e.g. "In Progress"). */
+  state: string;
+  branchName: string;
+  url: string;
+  updatedAt: Date;
+}
+
 export interface LinearContext {
   apiKey: string;
   teamKey: string;
@@ -125,6 +141,23 @@ export interface ListPRDsIssueFilter {
   state?: { type: { in: string[] } };
 }
 
+/**
+ * Filter shape consumed by `listStandaloneIssues` via the SDK's `issues`
+ * method. Mirrors the SDK's `IssueCollectionFilter` shape — `parent.null`
+ * tests for absence of a Linear parent, and `labels.{some,every}` are used
+ * to require the `ready-for-agent` label and forbid the `prd` label
+ * respectively.
+ */
+export interface ListStandaloneIssuesFilter {
+  team?: { id: { eq: string } };
+  parent?: { null: boolean };
+  state?: { type: { in: string[] } };
+  labels?:
+    | { some: { name: { eq: string } } }
+    | { every: { name: { neq: string } } };
+  and?: ListStandaloneIssuesFilter[];
+}
+
 interface ListPRDsIssueNode {
   id: string;
   identifier: string;
@@ -157,10 +190,14 @@ export interface ListPRDsClient {
 }
 
 /**
- * List every PRD (issue tagged with both `prd` and `ready-for-agent` on the
- * configured team, in a non-terminal workflow state) ordered by `updatedAt`
- * desc. Each PRD carries the count of its direct sub-issues split by
- * `ready-for-agent` / `ready-for-human` label.
+ * List every PRD (issue tagged with `prd` on the configured team, in a
+ * non-terminal workflow state, with at least one direct sub-issue carrying
+ * `ready-for-agent`) ordered by `updatedAt` desc. Each PRD carries the count
+ * of its direct sub-issues split by `ready-for-agent` / `ready-for-human`
+ * label.
+ *
+ * Standalone PRDs — `prd`-labeled issues with zero `ready-for-agent`
+ * direct children — are filtered out so they don't clutter the picker.
  *
  * `_client` is a test seam — production callers omit it and the real
  * `LinearClient` is constructed from `ctx.apiKey`.
@@ -176,10 +213,7 @@ export async function listPRDs(
     c.issues({
       filter: {
         team: { id: { eq: teamId } },
-        and: [
-          { labels: { name: { eq: PRD_LABEL } } },
-          { labels: { name: { eq: READY_FOR_AGENT_LABEL } } },
-        ],
+        and: [{ labels: { name: { eq: PRD_LABEL } } }],
         state: { type: { in: [...NON_TERMINAL_STATE_TYPES] } },
       },
       orderBy: PaginationOrderBy.UpdatedAt,
@@ -206,6 +240,7 @@ export async function listPRDs(
         },
       }),
     ]);
+    if (agentChildren.nodes.length === 0) continue;
     prds.push({
       id: issue.id,
       identifier: issue.identifier,
@@ -223,6 +258,83 @@ export async function listPRDs(
   }
 
   return prds;
+}
+
+interface ListStandaloneIssuesIssueNode {
+  id: string;
+  identifier: string;
+  title: string;
+  stateId: string | undefined;
+  branchName: string;
+  url: string;
+  updatedAt: Date;
+}
+
+/**
+ * Minimal subset of `LinearClient` consumed by `listStandaloneIssues`.
+ * Surfaced as a named seam so tests can drive the function without mocking
+ * the entire SDK.
+ */
+export interface ListStandaloneIssuesClient {
+  teams(args: { filter: { key: { eq: string } } }): Promise<{
+    nodes: { id: string }[];
+  }>;
+  workflowStates(args: { filter: { team: { id: { eq: string } } } }): Promise<{
+    nodes: { id: string; name: string; type: string; position: number }[];
+  }>;
+  issues(args: {
+    filter: ListStandaloneIssuesFilter;
+    orderBy?: PaginationOrderBy;
+  }): Promise<{ nodes: ListStandaloneIssuesIssueNode[] }>;
+}
+
+/**
+ * List every Standalone Issue (issue tagged with `ready-for-agent` on the
+ * configured team, with no Linear parent, not carrying the `prd` label, in
+ * a non-terminal workflow state) ordered by `updatedAt` desc.
+ *
+ * `_client` is a test seam — production callers omit it and the real
+ * `LinearClient` is constructed from `ctx.apiKey`.
+ */
+export async function listStandaloneIssues(
+  ctx: LinearContext,
+  _client?: ListStandaloneIssuesClient
+): Promise<StandaloneIssue[]> {
+  const c: ListStandaloneIssuesClient =
+    _client ?? (client(ctx.apiKey));
+  const teamId = await findTeamId(c, ctx.teamKey);
+
+  const [conn, statesConn] = await Promise.all([
+    c.issues({
+      filter: {
+        team: { id: { eq: teamId } },
+        parent: { null: true },
+        state: { type: { in: [...NON_TERMINAL_STATE_TYPES] } },
+        and: [
+          { labels: { some: { name: { eq: READY_FOR_AGENT_LABEL } } } },
+          { labels: { every: { name: { neq: PRD_LABEL } } } },
+        ],
+      },
+      orderBy: PaginationOrderBy.UpdatedAt,
+    }),
+    c.workflowStates({ filter: { team: { id: { eq: teamId } } } }),
+  ]);
+
+  const stateNameById = new Map<string, string>();
+  for (const s of statesConn.nodes) stateNameById.set(s.id, s.name);
+
+  return conn.nodes.map((issue) => ({
+    id: issue.id,
+    identifier: issue.identifier,
+    title: issue.title,
+    state:
+      typeof issue.stateId === "string"
+        ? (stateNameById.get(issue.stateId) ?? "")
+        : "",
+    branchName: issue.branchName,
+    url: issue.url,
+    updatedAt: issue.updatedAt,
+  }));
 }
 
 async function findTeamId(

--- a/src/pr-submission/index.test.ts
+++ b/src/pr-submission/index.test.ts
@@ -180,9 +180,9 @@ describe("runPrSubmission", () => {
       ghRepo: baseGhRepo,
       branch: "feature/per-32",
       baseBranch: "master",
-      parentIdentifier: "MEC-123",
-      parentTitle: "PRD: example feature",
-      parentUrl: "https://linear.app/acme/issue/MEC-123",
+      rootIdentifier: "MEC-123",
+      rootTitle: "PRD: example feature",
+      rootUrl: "https://linear.app/acme/issue/MEC-123",
       subIssues: [
         { number: 8, title: "Foundation tracer" },
         { number: 9, title: "Pre-flight clack confirm" },
@@ -272,9 +272,9 @@ describe("runPrSubmission", () => {
         ghRepo: baseGhRepo,
         branch: "feature/per-32",
         baseBranch: "master",
-        parentIdentifier: "MEC-123",
-        parentTitle: "PRD",
-        parentUrl: "https://linear.app/acme/issue/MEC-123",
+        rootIdentifier: "MEC-123",
+        rootTitle: "PRD",
+        rootUrl: "https://linear.app/acme/issue/MEC-123",
         subIssues: [],
         repoRoot: "/repo",
         config: baseConfig,
@@ -298,9 +298,9 @@ describe("runPrSubmission", () => {
         ghRepo: baseGhRepo,
         branch: "feature/per-32",
         baseBranch: "master",
-        parentIdentifier: "MEC-123",
-        parentTitle: "PRD",
-        parentUrl: "https://linear.app/acme/issue/MEC-123",
+        rootIdentifier: "MEC-123",
+        rootTitle: "PRD",
+        rootUrl: "https://linear.app/acme/issue/MEC-123",
         subIssues: [],
         repoRoot: "/repo",
         config: baseConfig,
@@ -318,9 +318,9 @@ describe("runPrSubmission", () => {
 
 describe("buildPrPromptArgs", () => {
   const baseInput = {
-    parentIdentifier: "MEC-123",
-    parentTitle: "PRD: example feature",
-    parentUrl: "https://linear.app/acme/issue/MEC-123",
+    rootIdentifier: "MEC-123",
+    rootTitle: "PRD: example feature",
+    rootUrl: "https://linear.app/acme/issue/MEC-123",
     branch: "feature/per-32",
     baseBranch: "master",
     repoOwner: "acme",
@@ -334,36 +334,38 @@ describe("buildPrPromptArgs", () => {
     });
     expect(Object.keys(args).sort()).toEqual(
       [
-        "PARENT_ID",
-        "PARENT_TITLE",
-        "PARENT_URL",
         "REPO_NAME",
         "REPO_OWNER",
+        "ROOT_ID",
+        "ROOT_TITLE",
+        "ROOT_URL",
         "SOURCE_BRANCH",
-        "SUB_ISSUES",
+        "SUB_ISSUES_BLOCK",
         "TARGET_BRANCH",
       ].sort()
     );
-    expect(args.PARENT_ID).toBe("MEC-123");
-    expect(args.PARENT_TITLE).toBe("PRD: example feature");
-    expect(args.PARENT_URL).toBe("https://linear.app/acme/issue/MEC-123");
+    expect(args.ROOT_ID).toBe("MEC-123");
+    expect(args.ROOT_TITLE).toBe("PRD: example feature");
+    expect(args.ROOT_URL).toBe("https://linear.app/acme/issue/MEC-123");
     expect(args.SOURCE_BRANCH).toBe("feature/per-32");
     expect(args.TARGET_BRANCH).toBe("master");
     expect(args.REPO_OWNER).toBe("acme");
     expect(args.REPO_NAME).toBe("widget");
   });
 
-  it("renders zero sub-issues with a stable placeholder rather than an empty list", () => {
+  it("omits the entire `Sub-issues addressed` block when subIssues is empty (Standalone Issue root)", () => {
     const args = buildPrPromptArgs({ ...baseInput, subIssues: [] });
-    expect(args.SUB_ISSUES).toBe("_(none)_");
+    expect(args.SUB_ISSUES_BLOCK).toBe("");
   });
 
-  it("renders one sub-issue as a single bullet line", () => {
+  it("renders one sub-issue under the `Sub-issues addressed` heading", () => {
     const args = buildPrPromptArgs({
       ...baseInput,
       subIssues: [{ number: 42, title: "Wire up the runner" }],
     });
-    expect(args.SUB_ISSUES).toBe("- #42 Wire up the runner");
+    expect(args.SUB_ISSUES_BLOCK).toBe(
+      "- Sub-issues addressed (in order):\n- #42 Wire up the runner"
+    );
   });
 
   it("renders many sub-issues in input order, one bullet per", () => {
@@ -375,8 +377,9 @@ describe("buildPrPromptArgs", () => {
         { number: 10, title: "Rev-list zero-commits gate" },
       ],
     });
-    expect(args.SUB_ISSUES).toBe(
+    expect(args.SUB_ISSUES_BLOCK).toBe(
       [
+        "- Sub-issues addressed (in order):",
         "- #8 Foundation tracer",
         "- #9 Pre-flight clack confirm",
         "- #10 Rev-list zero-commits gate",
@@ -387,20 +390,24 @@ describe("buildPrPromptArgs", () => {
   it("collapses newlines in user-controlled titles to spaces (escaping)", () => {
     const args = buildPrPromptArgs({
       ...baseInput,
-      parentTitle: "PRD: line one\nline two",
+      rootTitle: "PRD: line one\nline two",
       subIssues: [{ number: 100, title: "Title with\r\nembedded\rnewlines" }],
     });
-    expect(args.PARENT_TITLE).toBe("PRD: line one line two");
-    expect(args.SUB_ISSUES).toBe("- #100 Title with embedded newlines");
+    expect(args.ROOT_TITLE).toBe("PRD: line one line two");
+    expect(args.SUB_ISSUES_BLOCK).toBe(
+      "- Sub-issues addressed (in order):\n- #100 Title with embedded newlines"
+    );
   });
 
   it("trims surrounding whitespace from titles", () => {
     const args = buildPrPromptArgs({
       ...baseInput,
-      parentTitle: "  Padded PRD  ",
+      rootTitle: "  Padded PRD  ",
       subIssues: [{ number: 1, title: "  spaced  " }],
     });
-    expect(args.PARENT_TITLE).toBe("Padded PRD");
-    expect(args.SUB_ISSUES).toBe("- #1 spaced");
+    expect(args.ROOT_TITLE).toBe("Padded PRD");
+    expect(args.SUB_ISSUES_BLOCK).toBe(
+      "- Sub-issues addressed (in order):\n- #1 spaced"
+    );
   });
 });

--- a/src/pr-submission/index.ts
+++ b/src/pr-submission/index.ts
@@ -52,16 +52,19 @@ export interface RunPrSubmissionOptions {
   ghRepo: GhRepo;
   branch: string;
   baseBranch: string;
-  /** Linear PRD identifier (e.g. "MEC-123"). Informational only — there is
-   * no closing magic word emitted in the PR body. The PR↔PRD link is the
-   * branch name alone. */
-  parentIdentifier: string;
-  parentTitle: string;
-  /** Linear PRD URL. Informational only — surfaces in the body so reviewers
-   * can click through. */
-  parentUrl: string;
-  // Topo-ordered sub-issues addressed by this PR. Surfaces in the rendered
-  // prompt's Context section so the agent can scope its diff summary.
+  /** Linear root identifier (a PRD identifier for PRD roots, or a
+   * Standalone Issue identifier when run from a Standalone root, e.g.
+   * "MEC-123"). Informational only — there is no closing magic word
+   * emitted in the PR body. The PR↔root link is the branch name alone. */
+  rootIdentifier: string;
+  rootTitle: string;
+  /** Linear root URL. Informational only — surfaces in the body so
+   * reviewers can click through. */
+  rootUrl: string;
+  // Topo-ordered sub-issues addressed by this PR. Empty for Standalone
+  // Issue roots (the root itself is the unit of work). Surfaces in the
+  // rendered prompt's Context section when non-empty so the agent can
+  // scope its diff summary.
   subIssues: SubIssueRef[];
   repoRoot: string;
   config: TideConfig;
@@ -180,15 +183,14 @@ export async function resolveBaseBranch(
 //
 // Single-phase: no `<sub>Files-changed:</sub>` anchor links — those would
 // require a two-phase create-then-edit flow to inject post-creation URLs.
-const PR_PROMPT_TEMPLATE = `You are submitting a pull request for parent PRD {{PARENT_ID}}: {{PARENT_TITLE}}.
+const PR_PROMPT_TEMPLATE = `You are submitting a pull request rooted at Linear issue {{ROOT_ID}}: {{ROOT_TITLE}}.
 
 The current working branch is \`{{SOURCE_BRANCH}}\` (already pushed to origin). Open a pull request against the base branch \`{{TARGET_BRANCH}}\` for the repository \`{{REPO_OWNER}}/{{REPO_NAME}}\`.
 
 # Context
 
-- Parent PRD: {{PARENT_ID}} ({{PARENT_URL}})
-- Sub-issues addressed (in order):
-{{SUB_ISSUES}}
+- Linear root: {{ROOT_ID}} ({{ROOT_URL}})
+{{SUB_ISSUES_BLOCK}}
 
 # Title
 
@@ -267,11 +269,11 @@ When the PR has been opened successfully, emit <promise>DONE</promise> and exit.
 `;
 
 export interface BuildPrPromptArgsInput {
-  /** Linear PRD identifier (e.g. "MEC-123"). */
-  parentIdentifier: string;
-  parentTitle: string;
-  /** Linear PRD URL. */
-  parentUrl: string;
+  /** Linear root identifier (e.g. "MEC-123"). */
+  rootIdentifier: string;
+  rootTitle: string;
+  /** Linear root URL. */
+  rootUrl: string;
   branch: string;
   baseBranch: string;
   repoOwner: string;
@@ -281,8 +283,6 @@ export interface BuildPrPromptArgsInput {
 
 export type PrPromptArgsRecord = Record<string, string | number>;
 
-const SUB_ISSUES_NONE = "_(none)_";
-
 // Collapse internal whitespace runs (including embedded newlines and
 // carriage returns) to a single space, then trim. Keeps user-controlled
 // titles from breaking the markdown structure of the rendered prompt.
@@ -290,11 +290,12 @@ function sanitizeInline(value: string): string {
   return value.replace(/\s+/g, " ").trim();
 }
 
-function renderSubIssues(subs: readonly SubIssueRef[]): string {
-  if (subs.length === 0) return SUB_ISSUES_NONE;
-  return subs
+function renderSubIssuesBlock(subs: readonly SubIssueRef[]): string {
+  if (subs.length === 0) return "";
+  const bullets = subs
     .map((s) => `- #${String(s.number)} ${sanitizeInline(s.title)}`)
     .join("\n");
+  return `- Sub-issues addressed (in order):\n${bullets}`;
 }
 
 /**
@@ -302,20 +303,22 @@ function renderSubIssues(subs: readonly SubIssueRef[]): string {
  * template. Returns numbers as numbers and strings as strings so the
  * record matches the shape Sandcastle's `promptArgs` accepts. Titles are
  * inlined (newlines collapsed, trimmed) to keep template substitution from
- * breaking the surrounding markdown.
+ * breaking the surrounding markdown. The "Sub-issues addressed" block is
+ * rendered conditionally — present for PRD roots (non-empty subIssues),
+ * omitted for Standalone Issue roots (empty subIssues).
  */
 export function buildPrPromptArgs(
   input: BuildPrPromptArgsInput
 ): PrPromptArgsRecord {
   return {
-    PARENT_ID: input.parentIdentifier,
-    PARENT_TITLE: sanitizeInline(input.parentTitle),
-    PARENT_URL: input.parentUrl,
+    ROOT_ID: input.rootIdentifier,
+    ROOT_TITLE: sanitizeInline(input.rootTitle),
+    ROOT_URL: input.rootUrl,
     SOURCE_BRANCH: input.branch,
     TARGET_BRANCH: input.baseBranch,
     REPO_OWNER: input.repoOwner,
     REPO_NAME: input.repoName,
-    SUB_ISSUES: renderSubIssues(input.subIssues),
+    SUB_ISSUES_BLOCK: renderSubIssuesBlock(input.subIssues),
   };
 }
 
@@ -382,9 +385,9 @@ export async function runPrSubmission(
     ghRepo,
     branch,
     baseBranch,
-    parentIdentifier,
-    parentTitle,
-    parentUrl,
+    rootIdentifier,
+    rootTitle,
+    rootUrl,
     subIssues,
     repoRoot,
     config,
@@ -398,9 +401,9 @@ export async function runPrSubmission(
   // ships in tide source and is not user-editable. Uses the reusable-sandbox
   // pattern (`createSandbox` + `sandbox.run`) to match the runner's API.
   const promptArgs = buildPrPromptArgs({
-    parentIdentifier,
-    parentTitle,
-    parentUrl,
+    rootIdentifier,
+    rootTitle,
+    rootUrl,
     branch,
     baseBranch,
     repoOwner: ghRepo.owner,

--- a/src/prompt-args/index.test.ts
+++ b/src/prompt-args/index.test.ts
@@ -88,6 +88,29 @@ describe("buildPromptArgs", () => {
     expect(content).not.toContain("### Comments");
   });
 
+  it("omits PRD_CONTENT and PARENT_ID when parent is undefined (Standalone Issue root)", () => {
+    const issue: IssueContent = {
+      identifier: "ENG-300",
+      title: "Standalone issue",
+      body: "Direct body.",
+      comments: ["Note from triager"],
+    };
+    const args = buildPromptArgs({ issue });
+
+    expect(Object.keys(args).sort()).toEqual([
+      "ISSUE_CONTENT",
+      "ISSUE_ID",
+      "ISSUE_TITLE",
+    ]);
+    expect(args.ISSUE_ID).toBe("ENG-300");
+    expect(args.ISSUE_TITLE).toBe("Standalone issue");
+    const content = args.ISSUE_CONTENT as string;
+    expect(content).toContain("Direct body.");
+    expect(content).toContain("Note from triager");
+    expect(args.PRD_CONTENT).toBeUndefined();
+    expect(args.PARENT_ID).toBeUndefined();
+  });
+
   it("passes markdown special characters through verbatim (no escaping)", () => {
     const issue: IssueContent = {
       identifier: "ENG-202",

--- a/src/prompt-args/index.ts
+++ b/src/prompt-args/index.ts
@@ -1,12 +1,15 @@
 // Pure module: render the per-issue `promptArgs` record for a `run()` call.
 //
-// The five keys correspond to `{{KEY}}` placeholders in `.tide/prompt.md`:
-//   - ISSUE_ID:       the Linear identifier of the sub-issue (e.g. "ENG-7")
+// The keys correspond to `{{KEY}}` placeholders in the prompt template:
+//   - ISSUE_ID:       the Linear identifier of the in-scope issue
 //   - ISSUE_TITLE:    the issue's title string
 //   - ISSUE_CONTENT:  a markdown block with `Title`, `Body`, and `Comments`
 //                     sub-sections (Comments omitted if there are none)
-//   - PRD_CONTENT:    the parent PRD's raw markdown body
-//   - PARENT_ID:      the parent PRD's Linear identifier (e.g. "ENG-1")
+//   - PRD_CONTENT:    the parent PRD's raw markdown body (PRD root only)
+//   - PARENT_ID:      the parent PRD's Linear identifier (PRD root only)
+//
+// `parent` is optional. When omitted (Standalone Issue root), `PRD_CONTENT`
+// and `PARENT_ID` are omitted from the rendered args.
 //
 // SOURCE_BRANCH and TARGET_BRANCH are NOT included: sandcastle injects them
 // as built-in prompt arguments (driven by `branch`/`baseBranch` passed to
@@ -25,7 +28,7 @@ export interface IssueContent {
 
 export interface BuildPromptArgsInput {
   issue: IssueContent;
-  parent: IssueContent;
+  parent?: IssueContent;
 }
 
 export type PromptArgsRecord = Record<string, string | number | boolean>;
@@ -58,11 +61,14 @@ function renderIssueContent(issue: IssueContent): string {
 
 export function buildPromptArgs(input: BuildPromptArgsInput): PromptArgsRecord {
   const { issue, parent } = input;
-  return {
+  const args: PromptArgsRecord = {
     ISSUE_ID: issue.identifier,
     ISSUE_TITLE: issue.title,
     ISSUE_CONTENT: renderIssueContent(issue),
-    PRD_CONTENT: parent.body,
-    PARENT_ID: parent.identifier,
   };
+  if (parent !== undefined) {
+    args.PRD_CONTENT = parent.body;
+    args.PARENT_ID = parent.identifier;
+  }
+  return args;
 }

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -10,19 +10,29 @@
 // does not tail the log to stdout. The user inspects the .tide/logs file
 // after the run, or tails it themselves in a second terminal.
 //
-// For each Linear sub-issue in topo order:
-//   1. Fetch its body+comments (and the PRD's body once at the top) from
-//      Linear.
-//   2. Transition the sub-issue to *In Progress* in Linear.
+// The runner supports two root kinds via the `root` tagged union:
+//   - `kind: "prd"` — the queue iterates over a PRD's `ready-for-agent`
+//     sub-issues. The PRD's body is fetched once at the top and threaded
+//     through every iteration's prompt args (PRD_CONTENT / PARENT_ID).
+//     The PRD-rooted prompt template at `.tide/prompt.md` is used.
+//   - `kind: "standalone"` — the queue is a single Standalone Issue. No
+//     parent fetch happens; the iteration's prompt args omit the parent
+//     keys. The Standalone-Issue template at `.tide/prompt-standalone.md`
+//     is used.
+//
+// For each in-scope Linear issue in topo order:
+//   1. Fetch its body+comments (and the PRD's body once at the top, for
+//      PRD roots only) from Linear.
+//   2. Transition the issue to *In Progress* in Linear.
 //   3. Build promptArgs via the pure `buildPromptArgs` helper and call
-//      `sandbox.run(...)` with the working-agent prompt template.
+//      `sandbox.run(...)` with the appropriate prompt template.
 //   4. Dispatch on the iteration's outcome:
-//        - DONE + commits → host transitions the sub-issue to *Done*; queue
+//        - DONE + commits → host transitions the issue to *Done*; queue
 //          continues.
 //        - BLOCKED / agent-FAIL → run the summarizer agent in the same
 //          sandbox, extract its final assistant message via the
 //          `transcript-extract` module, post it as a Linear comment, then
-//          flip the sub-issue's label from `ready-for-agent` to
+//          flip the issue's label from `ready-for-agent` to
 //          `ready-for-human` and continue. If the summarizer itself fails
 //          (transcript unparseable, sandbox throws), tide falls back to a
 //          short placeholder comment that cites the underlying error.
@@ -87,6 +97,15 @@ export interface OrderedIssue {
 }
 
 /**
+ * Tagged-union descriptor of the root the runner is iterating under. PRD
+ * roots have an associated parent issue whose body hydrates every
+ * iteration's prompt args; Standalone roots have no parent.
+ */
+export type RunRoot =
+  | { kind: "prd"; id: string; identifier: string }
+  | { kind: "standalone" };
+
+/**
  * Test seam type: a function with the same shape as `sandbox.run(...)` from
  * `@ai-hero/sandcastle`. Tests pass a stub; production wires
  * `sandbox.run.bind(sandbox)` of a real `Sandbox` created by
@@ -138,10 +157,10 @@ async function defaultShellRunner(
 }
 
 export interface RunIssueQueueOptions {
-  /** PRD identifier (e.g. "ENG-1") — surfaced in prompt args as PARENT_ID. */
-  parentIdentifier: string;
-  /** PRD UUID — used to fetch the PRD body once for PRD_CONTENT. */
-  parentId: string;
+  /** Tagged-union root reference. PRD roots fetch the parent body once for
+   * PRD_CONTENT / PARENT_ID; Standalone roots skip the parent fetch and
+   * omit the parent keys from prompt args. */
+  root: RunRoot;
   orderedIssues: OrderedIssue[];
   /** Feature branch the agent commits to. Surfaced as BRANCH in prompt args. */
   branch: string;
@@ -290,12 +309,16 @@ function buildFallbackComment(
  * Run the summarizer agent inside the same sandbox, read its final
  * assistant message back from its log file, and return the comment body.
  * Throws on any failure; the caller falls back to a placeholder comment.
+ *
+ * For Standalone Issue roots there is no parent PRD; `parentContent` /
+ * `parentIdentifier` are undefined and the rendered prompt's parent fields
+ * fall through to empty placeholders.
  */
 async function runSummarizer(args: {
   kind: SummarizerPromptKind;
   workingAgentLogFilePath: string | undefined;
-  parentContent: LinearIssueContent;
-  parentIdentifier: string;
+  parentContent: LinearIssueContent | undefined;
+  parentIdentifier: string | undefined;
   issueContent: LinearIssueContent;
   sandboxRun: SandboxRunFn;
   readFinalAssistantMessage: (logFilePath: string) => Promise<string>;
@@ -312,9 +335,9 @@ async function runSummarizer(args: {
     issueIdentifier: args.issueContent.identifier,
     issueTitle: args.issueContent.title,
     issueBody: args.issueContent.body,
-    parentIdentifier: args.parentIdentifier,
-    parentTitle: args.parentContent.title,
-    parentBody: args.parentContent.body,
+    parentIdentifier: args.parentIdentifier ?? "",
+    parentTitle: args.parentContent?.title ?? "",
+    parentBody: args.parentContent?.body ?? "",
     transcript,
   });
 
@@ -392,8 +415,7 @@ export async function runIssueQueue(
   options: RunIssueQueueOptions
 ): Promise<RunIssueQueueResult> {
   const {
-    parentIdentifier,
-    parentId,
+    root,
     orderedIssues,
     branch,
     baseBranch,
@@ -416,14 +438,22 @@ export async function runIssueQueue(
   const createSandboxFn = options.createSandbox ?? defaultCreateSandbox;
   const shellRunner = options.shellRunner ?? defaultShellRunner;
 
-  // Fetch the parent body once for PRD_CONTENT — it's stable across the loop.
-  const parentContent = await fetchIssueContentFn(linearCtx, parentId);
+  // PRD root: fetch the parent body once for PRD_CONTENT — it's stable
+  // across the loop. Standalone root: no parent to fetch.
+  const parentContent: LinearIssueContent | undefined =
+    root.kind === "prd"
+      ? await fetchIssueContentFn(linearCtx, root.id)
+      : undefined;
 
-  // The prompt template lives in the host repo at .tide/prompt.md. The
-  // sandcastle SDK resolves promptFile against process.cwd() (per its docs),
-  // so we pass an absolute path to avoid ambiguity when the user invokes
-  // `tide run` from a subdirectory.
-  const promptFile = path.join(repoRoot, ".tide", "prompt.md");
+  // The prompt template lives in the host repo at .tide/. The PRD-rooted
+  // template is the long-standing `prompt.md`; the Standalone-Issue
+  // template `prompt-standalone.md` drops the "Parent PRD" section. The
+  // sandcastle SDK resolves promptFile against process.cwd() (per its
+  // docs), so we pass an absolute path to avoid ambiguity when the user
+  // invokes `tide run` from a subdirectory.
+  const promptFileName =
+    root.kind === "prd" ? "prompt.md" : "prompt-standalone.md";
+  const promptFile = path.join(repoRoot, ".tide", promptFileName);
 
   // Either use the test-supplied sandboxRun seam, or eagerly create one
   // sandbox for the entire queue. The reusable-sandbox shape lets us share
@@ -495,7 +525,10 @@ export async function runIssueQueue(
 
       const promptArgs = buildPromptArgs({
         issue: issueContent,
-        parent: { ...parentContent, identifier: parentIdentifier },
+        parent:
+          root.kind === "prd" && parentContent !== undefined
+            ? { ...parentContent, identifier: root.identifier }
+            : undefined,
       });
 
       const workingLogPath = buildLogPath({
@@ -576,7 +609,7 @@ export async function runIssueQueue(
             kind: summarizerKind,
             workingAgentLogFilePath: result.logFilePath,
             parentContent,
-            parentIdentifier,
+            parentIdentifier: root.kind === "prd" ? root.identifier : undefined,
             issueContent,
             sandboxRun,
             readFinalAssistantMessage,

--- a/src/runner/runner.test.ts
+++ b/src/runner/runner.test.ts
@@ -87,8 +87,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     const events: string[] = [];
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng-1",
       baseBranch: "master",
@@ -134,8 +133,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     let runCount = 0;
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [
         makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
         makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),
@@ -241,8 +239,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     let runCount = 0;
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [
         makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
         makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),
@@ -339,8 +336,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     let capturedSignal: string | string[] | undefined;
 
     await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng-1",
       baseBranch: "master",
@@ -374,8 +370,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     const events: string[] = [];
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng-1",
       baseBranch: "master",
@@ -438,8 +433,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     const events: string[] = [];
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng-1",
       baseBranch: "master",
@@ -501,8 +495,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     let runCount = 0;
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng-1",
       baseBranch: "master",
@@ -551,8 +544,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     let runCount = 0;
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng-1",
       baseBranch: "master",
@@ -602,8 +594,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     const events: string[] = [];
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [
         makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
         makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),
@@ -662,8 +653,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     const events: string[] = [];
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng-1",
       baseBranch: "master",
@@ -693,8 +683,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     const events: string[] = [];
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [
         makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
         makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),
@@ -741,8 +730,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
     const doneCalls: string[] = [];
 
     await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered({ id: "uuid-eng-1" })],
       branch: "feature/eng",
       baseBranch: "master",
@@ -772,8 +760,7 @@ describe("runIssueQueue — prompt args + sandcastle wiring", () => {
     let capturedOpts: SandboxRunOptions | undefined;
 
     await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered({ id: "uuid-eng-7", identifier: "ENG-7" })],
       branch: "user/feature/eng-7",
       baseBranch: "main",
@@ -812,8 +799,7 @@ describe("runIssueQueue — prompt args + sandcastle wiring", () => {
     let capturedOpts: SandboxRunOptions | undefined;
 
     await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng-1",
       baseBranch: "master",
@@ -844,8 +830,7 @@ describe("runIssueQueue — prompt args + sandcastle wiring", () => {
     let runCount = 0;
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng",
       baseBranch: "master",
@@ -902,8 +887,7 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
     const { runner, calls } = recordingShellRunner();
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng-1",
       baseBranch: "master",
@@ -929,8 +913,7 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
     const { runner, calls } = recordingShellRunner();
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng-1",
       baseBranch: "master",
@@ -977,8 +960,7 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
     const { runner, calls } = recordingShellRunner();
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [makeOrdered()],
       branch: "feature/eng-1",
       baseBranch: "master",
@@ -1013,8 +995,7 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
     });
 
     const result = await runIssueQueue({
-      parentIdentifier: "ENG-100",
-      parentId: "uuid-prd",
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
       orderedIssues: [
         makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
         makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),

--- a/src/selector/index.ts
+++ b/src/selector/index.ts
@@ -1,44 +1,71 @@
 // Interactive clack selector for the Linear-native flow.
 //
-//   - pickPRD: render the list of PRDs returned by `linear.listPRDs` as a
-//     clack `select`. Each option is rendered as
-//       `{identifier} {title} — {n} ready-for-agent, {m} ready-for-human`
-//     in the order the caller passed in (caller is responsible for ordering;
-//     `linear.listPRDs` returns them sorted by `updatedAt` desc).
+//   - pickRoot: render the list of PRDs and Standalone Issues returned by
+//     `linear.listPRDs` / `linear.listStandaloneIssues` as a single clack
+//     `select`. PRDs are grouped first, then Standalone Issues. Each row is
+//     prefixed with `[PRD]` or `[Issue]` so the kind is unambiguous in logs
+//     and screen-readers.
 //
-// There is no "[Create new Linear PRD]" path: PRDs must be authored in
-// Linear's UI before `tide run`.
+// There is no "[Create new Linear PRD]" path: PRDs and Standalone Issues
+// must be authored in Linear's UI before `tide run`.
 
 import { select, isCancel, cancel } from "@clack/prompts";
-import type { PRD } from "../linear/index.ts";
+import type { PRD, StandaloneIssue } from "../linear/index.ts";
+
+export type RootRef =
+  | { kind: "prd"; prd: PRD }
+  | { kind: "standalone"; issue: StandaloneIssue };
+
+export interface PickRootInput {
+  prds: readonly PRD[];
+  standaloneIssues: readonly StandaloneIssue[];
+}
+
+interface OptionEntry {
+  ref: RootRef;
+  label: string;
+}
 
 /**
- * Render a clack select over `prds`. Returns the picked PRD; on user cancel,
- * prints "Cancelled." and exits the process with code 0.
+ * Render a clack select grouping PRDs first, then Standalone Issues.
+ * Returns the picked root as a tagged union; on user cancel, prints
+ * "Cancelled." and exits the process with code 0.
  *
- * Pre-condition: `prds.length > 0`. The caller is responsible for handling
- * the empty case (no PRDs to pick from is its own UI flow).
+ * Pre-condition: at least one of `prds` / `standaloneIssues` is non-empty.
+ * The caller is responsible for handling the empty case (no roots to pick
+ * from is its own UI flow).
  */
-export async function pickPRD(prds: readonly PRD[]): Promise<PRD> {
-  const options = prds.map((prd, i) => ({
-    value: i,
-    label: `${prd.identifier} ${prd.title} — ${String(prd.readyForAgentCount)} ready-for-agent, ${String(prd.readyForHumanCount)} ready-for-human`,
-  }));
+export async function pickRoot(input: PickRootInput): Promise<RootRef> {
+  const entries: OptionEntry[] = [];
+  for (const prd of input.prds) {
+    entries.push({
+      ref: { kind: "prd", prd },
+      label: `[PRD] ${prd.identifier} ${prd.title} — ${String(prd.readyForAgentCount)} ready-for-agent, ${String(prd.readyForHumanCount)} ready-for-human`,
+    });
+  }
+  for (const issue of input.standaloneIssues) {
+    entries.push({
+      ref: { kind: "standalone", issue },
+      label: `[Issue] ${issue.identifier} ${issue.title}`,
+    });
+  }
+
+  const options = entries.map((e, i) => ({ value: i, label: e.label }));
 
   const choice = await select<number>({
-    message: "Pick a Linear PRD:",
+    message: "Pick a Linear root (PRD or Standalone Issue):",
     options,
   });
   if (isCancel(choice)) {
     cancel("Cancelled.");
     process.exit(0);
   }
-  const prd = prds[choice];
-  if (!prd) {
+  const entry = entries[choice];
+  if (!entry) {
     // Should be impossible: choice is one of the values we passed in.
     throw new Error(
-      `Internal error: picked PRD index ${String(choice)} not in list`
+      `Internal error: picked root index ${String(choice)} not in list`
     );
   }
-  return prd;
+  return entry.ref;
 }


### PR DESCRIPTION
## 🚩 The Problem

- `tide run` could only iterate under a PRD-rooted queue — Linear issues that didn't belong to a PRD had no way to be picked up by the agent.
- The PRD picker also surfaced "PRDs" that had no `ready-for-agent` children, so users would select a PRD and immediately fall through to a confusing standalone-PRD path.
- The PR template, runner options, and selector all hard-coded the word "parent" for the PRD, so there was no clean shape for a root that has no parent at all.
- A non-PRD issue with Linear children would silently look like a Standalone candidate, when in fact it should be re-labeled as a PRD or have its children removed.

## 💡 The Solution

- **Widen** `tide run` to accept two kinds of roots — PRDs and Standalone Issues — represented as a `RootRef` tagged union (`{ kind: "prd", prd } | { kind: "standalone", issue }`) threaded from the picker through the runner and PR-tail.
- **Deepen** `linear` with a new `listStandaloneIssues` query (`ready-for-agent`, no parent, not `prd`-labeled, non-terminal state); narrow `listPRDs` to require at least one `ready-for-agent` direct child so the picker only shows actionable roots.
- **Extract** prompt-template selection into the runner: PRD roots use the long-standing `.tide/prompt.md`; Standalone Issue roots use a new `.tide/prompt-standalone.md` that drops the "Parent PRD" section. `buildPromptArgs` now treats `parent` as optional.
- Validate the "no Linear children" contract for Standalone Issue roots **post-confirm**, so a user who cancels at the pre-flight prompt never sees a structural error; and emit an end-of-run BLOCKED warning when a Standalone root completes zero iterations and is flipped to `ready-for-human`.

## 🏗 Interface Movements

| Symbol | Old location | New location | Notes |
| --- | --- | --- | --- |
| `pickPRD(prds)` | `src/selector/index.ts` | — | Removed; replaced by `pickRoot`. |
| `pickRoot({ prds, standaloneIssues })` | — | `src/selector/index.ts` | New. Returns `RootRef` tagged union; renders one list with `[PRD]` / `[Issue]` prefixes. |
| `RootRef`, `PickRootInput` | — | `src/selector/index.ts` | New exports. |
| `listStandaloneIssues(ctx)` | — | `src/linear/index.ts` | New. Filters: `ready-for-agent` label, `parent: null`, no `prd` label, non-terminal state. |
| `StandaloneIssue`, `ListStandaloneIssuesClient`, `ListStandaloneIssuesFilter` | — | `src/linear/index.ts` | New exports. |
| `listPRDs(ctx)` | `src/linear/index.ts` | `src/linear/index.ts` | Filter widened: any `prd`-labeled issue, then post-filtered to those with ≥1 `ready-for-agent` direct child. PRDs without actionable children are now omitted. |
| `RunIssueQueueOptions.parentIdentifier` / `parentId` | `src/runner/index.ts` | — | Replaced by `root: RunRoot`. |
| `RunRoot` | — | `src/runner/index.ts` | New. `{ kind: "prd"; id; identifier } \| { kind: "standalone" }`. |
| `BuildPromptArgsInput.parent` | `src/prompt-args/index.ts` | `src/prompt-args/index.ts` | Now optional. When omitted, `PRD_CONTENT` / `PARENT_ID` are omitted from rendered args. |
| `BuildPrPromptArgsInput.parentIdentifier` / `parentTitle` / `parentUrl` | `src/pr-submission/index.ts` | `src/pr-submission/index.ts` | Renamed to `rootIdentifier` / `rootTitle` / `rootUrl`. |
| PR template keys `PARENT_ID` / `PARENT_TITLE` / `PARENT_URL` / `SUB_ISSUES` | `src/pr-submission/index.ts` | `src/pr-submission/index.ts` | Renamed to `ROOT_ID` / `ROOT_TITLE` / `ROOT_URL` / `SUB_ISSUES_BLOCK`. The block is rendered conditionally and omitted entirely for Standalone Issue roots. |
| `RunPrTailStepOptions.parentIdentifier` / `parentTitle` / `parentUrl` | `src/cli/run.ts` | `src/cli/run.ts` | Renamed to `rootIdentifier` / `rootTitle` / `rootUrl`. |
| `RunQueueAfterPickOptions.picked: PRD` | `src/cli/run.ts` | `src/cli/run.ts` | Now `picked: RootRef`. |
| `RunQueueAfterPickOptions.transitionPrdToInProgress` | `src/cli/run.ts` | `src/cli/run.ts` | Renamed to `transitionRootToInProgress`. |
| `RunOptions.pickPRD` | `src/cli/run.ts` | `src/cli/run.ts` | Renamed to `pickRoot`; signature changed to `({ prds, standaloneIssues }) => Promise<RootRef>`. |
| `RunOptions.listStandaloneIssues` | — | `src/cli/run.ts` | New test seam. |
| `.tide/prompt-standalone.md` | — | `.tide/` (and `src/cli/init-templates/`) | New init template — Standalone Issue prompt without the "Parent PRD" section. Written by `tide init`. |

## 📦 Package Breakdowns

<details>
<summary><code>src/cli/</code> — wire two-list fetch, dispatch on root kind, post-confirm child check</summary>

- `run.ts`: fetch PRDs and Standalone Issues in parallel; render selection log with `[PRD]` / `[Issue]` prefixes; introduce `rootMetaFromPicked` to flatten the tagged union; for PRD roots run the existing topo-queue path, for Standalone roots build a one-element queue and validate "no Linear children" only after the user confirms; rename `transitionPrdToInProgress` → `transitionRootToInProgress`; emit a Standalone-specific BLOCKED warning at end-of-run when `completed === 0 && flipped > 0`; generalize the no-merge warning to use `PRD` / `Issue` label depending on root kind.
- `init.ts` + `init-templates.d.ts`: ship and register the new `prompt-standalone.md` template so `tide init` writes it alongside `prompt.md`.

</details>

<details>
<summary><code>src/linear/</code> — new <code>listStandaloneIssues</code>, narrowed <code>listPRDs</code></summary>

- Add `StandaloneIssue` interface and `listStandaloneIssues(ctx)` driven by a new `ListStandaloneIssuesFilter` shape (uses `parent: { null: true }`, `labels.some` for `ready-for-agent`, `labels.every` for "no `prd`").
- Narrow `listPRDs`: drop the `ready-for-agent`-on-PRD filter clause; instead post-filter the results so only PRDs with ≥1 `ready-for-agent` direct child are returned. Standalone PRDs no longer clutter the picker.
- Module-level docstring updated to describe both queries.

</details>

<details>
<summary><code>src/runner/</code> — accept a tagged-union <code>root</code>, pick the right prompt template</summary>

- Replace `parentIdentifier` / `parentId` on `RunIssueQueueOptions` with `root: RunRoot`. PRD roots fetch the parent body once for `PRD_CONTENT` / `PARENT_ID`; Standalone roots skip the fetch and pass `parent: undefined` through to `buildPromptArgs`.
- Select the prompt template per root kind: `.tide/prompt.md` for PRD, `.tide/prompt-standalone.md` for Standalone.
- Summarizer path widened: `parentContent` and `parentIdentifier` are now optional and fall through to empty strings when there is no parent PRD.

</details>

<details>
<summary><code>src/pr-submission/</code> — rename Parent → Root in template + args</summary>

- Rename `parentIdentifier` / `parentTitle` / `parentUrl` to `rootIdentifier` / `rootTitle` / `rootUrl` throughout `RunPrSubmissionOptions`, `BuildPrPromptArgsInput`, and `runPrSubmission`.
- Template substitutions renamed (`PARENT_*` → `ROOT_*`); `SUB_ISSUES` becomes a `SUB_ISSUES_BLOCK` that renders the whole "Sub-issues addressed (in order):" block when there are sub-issues and is empty for Standalone roots — so the template doesn't emit a header with no list under it.

</details>

<details>
<summary><code>src/prompt-args/</code> — make <code>parent</code> optional</summary>

- `BuildPromptArgsInput.parent` is now optional. When omitted, `PRD_CONTENT` and `PARENT_ID` are omitted from the rendered record (rather than being set to empty strings) so Standalone-Issue prompt templates aren't tempted to interpolate stale parent placeholders.

</details>

<details>
<summary><code>.tide/</code> — Standalone Issue prompt template</summary>

- New `.tide/prompt-standalone.md` mirrors `prompt.md` but drops the "Parent PRD" section and addresses the agent against a single Linear issue. Same DONE/BLOCKED contract.

</details>

## 🧹 Housekeeping & Secondary Changes

- `src/runner/runner.test.ts`, `src/cli/run.test.ts`, `src/linear/index.test.ts`, `src/pr-submission/index.test.ts`, `src/prompt-args/index.test.ts`, `src/cli/init.test.ts`: updated to the new option shapes (`root: { kind: ... }`, `rootRef`, `rootIdentifier`, `pickRoot`, etc.) and new coverage added for Standalone discovery, the post-confirm child-check, the end-of-run BLOCKED warning, and the new init-template wiring.
