### PR TITLE
feat(runner): rebuild PRD queue at every iteration boundary

### DIFF
--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -1087,7 +1087,7 @@ describe("runQueueAfterPick — feature-branch guard", () => {
       },
       runIssueQueue: () => {
         runIssueQueueCalls += 1;
-        return Promise.resolve({ completed: 0, flipped: 0 });
+        return Promise.resolve({ completed: 0, flipped: 0, processed: [] });
       },
       runPrTailStep: () => {
         runPrTailStepCalls += 1;
@@ -1144,7 +1144,8 @@ describe("runQueueAfterPick — feature-branch guard", () => {
         // here is fine — we only care that the guard didn't preempt.
         return Promise.reject(new Error("stop here"));
       },
-      runIssueQueue: () => Promise.resolve({ completed: 0, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 0, flipped: 0, processed: [] }),
       runPrTailStep: () =>
         Promise.resolve({
           outcome: { kind: "opted-out" },
@@ -1205,7 +1206,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
       },
       runIssueQueue: () => {
         events.push("runIssueQueue");
-        return Promise.resolve({ completed: 1, flipped: 0 });
+        return Promise.resolve({ completed: 1, flipped: 0, processed: [] });
       },
       runPrTailStep: () => {
         events.push("runPrTailStep");
@@ -1259,7 +1260,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
       runIssueQueue: () => {
         runIssueQueueCalls += 1;
-        return Promise.resolve({ completed: 0, flipped: 0 });
+        return Promise.resolve({ completed: 0, flipped: 0, processed: [] });
       },
       runPrTailStep: () =>
         Promise.resolve({
@@ -1295,7 +1296,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
       runIssueQueue: () => {
         runIssueQueueCalls += 1;
-        return Promise.resolve({ completed: 0, flipped: 0 });
+        return Promise.resolve({ completed: 0, flipped: 0, processed: [] });
       },
       runPrTailStep: () =>
         Promise.resolve({
@@ -1336,7 +1337,7 @@ describe("runQueueAfterPick — PRD In Progress transition", () => {
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
       runIssueQueue: (opts) => {
         capturedBaseBranch = opts.baseBranch;
-        return Promise.resolve({ completed: 1, flipped: 0 });
+        return Promise.resolve({ completed: 1, flipped: 0, processed: [] });
       },
       runPrTailStep: () =>
         Promise.resolve({
@@ -1419,7 +1420,8 @@ describe("runQueueAfterPick — ready-for-human preflight skip log", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve(subIssues),
-      runIssueQueue: () => Promise.resolve({ completed: 2, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 2, flipped: 0, processed: [] }),
       runPrTailStep: () =>
         Promise.resolve({
           outcome: { kind: "opted-out" },
@@ -1461,7 +1463,8 @@ describe("runQueueAfterPick — ready-for-human preflight skip log", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve(subIssues),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: () =>
         Promise.resolve({
           outcome: { kind: "opted-out" },
@@ -1516,7 +1519,8 @@ describe("runQueueAfterPick — end-of-run no-merge warning", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: tail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(true),
@@ -1649,7 +1653,8 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
       sandboxEnv: {},
       // No children — the no-children validator must succeed.
       fetchSubIssues: () => Promise.resolve([]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: () =>
         Promise.resolve({
           outcome: { kind: "opened", url: "https://example/pr/1" },
@@ -1690,7 +1695,7 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
       runIssueQueue: (opts) => {
         capturedOrdered = opts.orderedIssues;
         capturedRoot = opts.root;
-        return Promise.resolve({ completed: 1, flipped: 0 });
+        return Promise.resolve({ completed: 1, flipped: 0, processed: [] });
       },
       runPrTailStep: () =>
         Promise.resolve({
@@ -1736,7 +1741,7 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
         ] as SubIssue[]),
       runIssueQueue: () => {
         runIssueQueueCalls += 1;
-        return Promise.resolve({ completed: 0, flipped: 0 });
+        return Promise.resolve({ completed: 0, flipped: 0, processed: [] });
       },
       runPrTailStep: () =>
         Promise.resolve({
@@ -1795,7 +1800,7 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
       },
       runIssueQueue: () => {
         runIssueQueueCalls += 1;
-        return Promise.resolve({ completed: 0, flipped: 0 });
+        return Promise.resolve({ completed: 0, flipped: 0, processed: [] });
       },
       runPrTailStep: () =>
         Promise.resolve({
@@ -1831,7 +1836,8 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([]),
-      runIssueQueue: () => Promise.resolve({ completed: 0, flipped: 1 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 0, flipped: 1, processed: [] }),
       runPrTailStep: () =>
         Promise.resolve({
           outcome: { kind: "opted-out" },
@@ -1868,7 +1874,8 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: () =>
         Promise.resolve({
           outcome: { kind: "opened", url: "https://example/pr/1" },
@@ -1908,7 +1915,8 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
       // `ready-for-human`. The Standalone-specific warning must not fire —
       // the per-sub-issue warning (logged inside the runner, not here) is
       // the only BLOCKED hand-off the user should see.
-      runIssueQueue: () => Promise.resolve({ completed: 0, flipped: 1 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 0, flipped: 1, processed: [] }),
       runPrTailStep: () =>
         Promise.resolve({
           outcome: { kind: "opted-out" },
@@ -1939,7 +1947,8 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: () =>
         Promise.resolve({
           outcome: { kind: "opened", url: "https://example/pr/1" },
@@ -1970,7 +1979,8 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: (opts) => {
         capturedSubIssues = opts.subIssues;
         return Promise.resolve({
@@ -1985,6 +1995,70 @@ describe("runQueueAfterPick — Standalone Issue root", () => {
     });
 
     expect(capturedSubIssues).toEqual([]);
+  });
+});
+
+describe("runQueueAfterPick — PR-tail subIssueRefs come from runner.processed (ADR-0010)", () => {
+  const baseConfig: TideConfig = {
+    linear: { team: "ENG" },
+    sandbox: { mounts: [] },
+    hooks: { onSandboxReady: [] },
+  };
+
+  test("PRD root: PR body's Sub-issues addressed block is built from result.processed, not the pre-flight orderedIssues", async () => {
+    const picked = makePRD({ id: "uuid-eng-1", identifier: "ENG-1" });
+    let capturedSubIssues: { number: number; title: string }[] | undefined;
+
+    await runQueueAfterPick({
+      picked: prdRoot(picked),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      // Pre-flight returns one ready-for-agent sub-issue.
+      fetchSubIssues: () =>
+        Promise.resolve([
+          {
+            id: "uuid-2",
+            identifier: "ENG-2",
+            title: "Initial",
+            state: "Backlog",
+            stateType: "backlog",
+            labels: ["ready-for-agent"],
+            blockedBy: [],
+          },
+        ] as SubIssue[]),
+      // Runner reports it processed two — initial + one absorbed via the
+      // mid-run queue rebuild (ENG-3). The PR-tail step must reflect both.
+      runIssueQueue: () =>
+        Promise.resolve({
+          completed: 2,
+          flipped: 0,
+          processed: [
+            { id: "uuid-2", identifier: "ENG-2", title: "Initial" },
+            { id: "uuid-3", identifier: "ENG-3", title: "Absorbed" },
+          ],
+        }),
+      runPrTailStep: (opts) => {
+        capturedSubIssues = opts.subIssues;
+        return Promise.resolve({
+          outcome: { kind: "opened", url: "https://example/pr/1" },
+          outroMessage: "ok",
+          exitCode: 0,
+        } satisfies PrTailStepResult);
+      },
+      confirmRun: () => Promise.resolve(true),
+      confirmPr: () => Promise.resolve(true),
+      transitionRootToInProgress: () => Promise.resolve(),
+      transitionRootToInReview: () => Promise.resolve(),
+    });
+
+    expect(capturedSubIssues).toEqual([
+      { number: 1, title: "ENG-2 Initial" },
+      { number: 2, title: "ENG-3 Absorbed" },
+    ]);
   });
 });
 
@@ -2042,7 +2116,8 @@ describe("runQueueAfterPick — post-submission In Review hook", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: openedTail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(true),
@@ -2072,7 +2147,8 @@ describe("runQueueAfterPick — post-submission In Review hook", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: optedOutTail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(false),
@@ -2102,7 +2178,8 @@ describe("runQueueAfterPick — post-submission In Review hook", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 1 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 1, processed: [] }),
       runPrTailStep: openedTail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(true),
@@ -2133,7 +2210,8 @@ describe("runQueueAfterPick — post-submission In Review hook", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
-      runIssueQueue: () => Promise.resolve({ completed: 0, flipped: 1 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 0, flipped: 1, processed: [] }),
       runPrTailStep: optedOutTail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(false),
@@ -2162,7 +2240,8 @@ describe("runQueueAfterPick — post-submission In Review hook", () => {
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: openedTail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(true),
@@ -2240,7 +2319,8 @@ describe("runQueueAfterPick — post-submission In Review hook (Standalone Issue
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: openedTail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(true),
@@ -2270,7 +2350,8 @@ describe("runQueueAfterPick — post-submission In Review hook (Standalone Issue
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: optedOutTail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(false),
@@ -2300,7 +2381,8 @@ describe("runQueueAfterPick — post-submission In Review hook (Standalone Issue
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
-      runIssueQueue: () => Promise.resolve({ completed: 0, flipped: 1 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 0, flipped: 1, processed: [] }),
       runPrTailStep: openedTail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(true),
@@ -2332,7 +2414,8 @@ describe("runQueueAfterPick — post-submission In Review hook (Standalone Issue
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
-      runIssueQueue: () => Promise.resolve({ completed: 0, flipped: 1 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 0, flipped: 1, processed: [] }),
       runPrTailStep: optedOutTail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(false),
@@ -2362,7 +2445,8 @@ describe("runQueueAfterPick — post-submission In Review hook (Standalone Issue
       config: baseConfig,
       sandboxEnv: {},
       fetchSubIssues: () => Promise.resolve([] as SubIssue[]),
-      runIssueQueue: () => Promise.resolve({ completed: 1, flipped: 0 }),
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
       runPrTailStep: openedTail,
       confirmRun: () => Promise.resolve(true),
       confirmPr: () => Promise.resolve(true),

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -33,8 +33,12 @@ import {
 } from "@clack/prompts";
 import { build as defaultBuild, type BuildOptions } from "./build.ts";
 import { loadConfig, type TideConfig } from "../config-loader/index.ts";
-import { type DepNode, topoSort } from "../dep-graph/index.ts";
 import { loadEnv } from "../env-loader/index.ts";
+import {
+  buildOrderedQueue,
+  type BuildOrderedQueueResult,
+  type OrderedSubIssue,
+} from "../queue-build/index.ts";
 import {
   getGhIdentity as defaultGetGhIdentity,
   type GetGhIdentityOptions,
@@ -78,9 +82,10 @@ import {
   type RootRef,
 } from "../selector/index.ts";
 
-const READY_FOR_AGENT = "ready-for-agent";
 const READY_FOR_HUMAN = "ready-for-human";
-const TERMINAL_STATE_TYPES = new Set(["completed", "canceled"]);
+
+export { buildOrderedQueue };
+export type { BuildOrderedQueueResult, OrderedSubIssue };
 
 export interface RunOptions {
   /** Repo root override (defaults to repo-discovery from cwd). */
@@ -202,106 +207,6 @@ export interface PrTailStepResult {
   outcome: PrTailOutcome;
   outroMessage: string;
   exitCode: 0 | 1;
-}
-
-export interface OrderedSubIssue {
-  /** Linear UUID. */
-  id: string;
-  identifier: string;
-  title: string;
-}
-
-export type BuildOrderedQueueResult =
-  | { kind: "queue"; ordered: OrderedSubIssue[] }
-  | { kind: "standalone" }
-  | { kind: "error"; message: string };
-
-/**
- * Pure: turn the picked PRD's direct sub-issues into an ordered queue.
- *
- * - Filters to direct children carrying the `ready-for-agent` label.
- * - If the filtered set is empty, returns `kind: "standalone"` — the caller
- *   treats the PRD itself as the unit of work.
- * - Closed (terminal-state) direct-child blockers are treated as satisfied.
- * - A `blockedBy` reference outside the picked PRD's children surfaces as
- *   an error mirroring the GitHub-path message shape.
- * - A cycle among open scoped sub-issues surfaces as a cycle error.
- */
-export function buildOrderedQueue(
-  subIssues: readonly SubIssue[]
-): BuildOrderedQueueResult {
-  const inScope = subIssues.filter((s) => s.labels.includes(READY_FOR_AGENT));
-  if (inScope.length === 0) {
-    return { kind: "standalone" };
-  }
-  const closedAmongDirectChildren = new Map(
-    subIssues.map(
-      (s) => [s.identifier, TERMINAL_STATE_TYPES.has(s.stateType)] as const
-    )
-  );
-
-  const nodes: DepNode[] = inScope.map((s) => {
-    const filtered = s.blockedBy.filter(
-      // Drop blockers that are direct children in a terminal state — those
-      // are satisfied. Any other blocker either is an in-scope sub-issue
-      // (handled by topoSort) or surfaces as an external-blocker error.
-      (b) => closedAmongDirectChildren.get(b) !== true
-    );
-    return {
-      id: s.identifier,
-      blockedBy: filtered,
-      closed: TERMINAL_STATE_TYPES.has(s.stateType),
-    };
-  });
-
-  const result = topoSort(nodes);
-  if (!result.ok) {
-    if (result.error.kind === "external-blocker") {
-      const { issue, blocker } = result.error;
-      // The blocker is in the picked PRD's direct children iff it appears in
-      // `closedAmongDirectChildren` (which maps every direct child, not just
-      // in-scope ones). Distinguish "out-of-scope direct child" from "truly
-      // outside the PRD" so the message points at the right fix.
-      const blockerDirectChild = subIssues.find(
-        (s) => s.identifier === blocker
-      );
-      if (blockerDirectChild) {
-        const labelHint = blockerDirectChild.labels.includes(READY_FOR_HUMAN)
-          ? "carries `ready-for-human` (flagged for human review)"
-          : "is missing the `ready-for-agent` label";
-        return {
-          kind: "error",
-          message:
-            `Sub-issue ${issue} is blocked by ${blocker}, a direct child of the picked PRD that ${labelHint}.\n` +
-            `Resolve in Linear: re-add \`ready-for-agent\` to the blocker, remove the relationship, or close the blocker.`,
-        };
-      }
-      return {
-        kind: "error",
-        message:
-          `Sub-issue ${issue} is blocked by ${blocker}, which is open and outside the picked PRD's children.\n` +
-          `Resolve by closing the blocker, removing the relationship, or expanding scope.`,
-      };
-    }
-    const edges = result.error.edges
-      .map((e) => `  ${e.from} -> ${e.to}`)
-      .join("\n");
-    return {
-      kind: "error",
-      message:
-        `Dependency graph contains a cycle. Offending edges:\n${edges}\n\n` +
-        "Resolve by removing one of the `blocked by` relationships in Linear, then re-run.",
-    };
-  }
-
-  const byIdentifier = new Map(inScope.map((s) => [s.identifier, s]));
-  const ordered: OrderedSubIssue[] = [];
-  for (const id of result.order) {
-    const sub = byIdentifier.get(id);
-    if (!sub) continue;
-    ordered.push({ id: sub.id, identifier: sub.identifier, title: sub.title });
-  }
-  return { kind: "queue", ordered };
 }
 
 /**
@@ -608,13 +513,15 @@ export async function runQueueAfterPick(
     return 1;
   }
 
-  // Convert ordered queue into the PR-tail's SubIssueRef shape. For PRD
-  // roots we surface the topo-ordered sub-issues as numbered bullets so the
-  // template renders the "Sub-issues addressed" block. For Standalone Issue
-  // roots we pass an empty list — the block is omitted entirely.
+  // Convert the runner's ordered list of *actually-processed* sub-issues
+  // (initial + any absorbed mid-run via ADR-0010's queue rebuild) into the
+  // PR-tail's SubIssueRef shape. For PRD roots we surface them as numbered
+  // bullets so the template renders the "Sub-issues addressed" block; for
+  // Standalone Issue roots we pass an empty list — the block is omitted
+  // entirely.
   const subIssueRefs: SubIssueRef[] =
     opts.picked.kind === "prd"
-      ? orderedIssues.map((o, i) => ({
+      ? queueResult.processed.map((o, i) => ({
           number: i + 1,
           title: `${o.identifier} ${o.title}`,
         }))

--- a/src/queue-build/index.ts
+++ b/src/queue-build/index.ts
@@ -1,0 +1,112 @@
+// Pure topo-ordering of a PRD's direct sub-issues.
+//
+// Extracted so both the CLI's pre-flight queue build and the runner's
+// per-iteration queue rebuild (ADR-0010) can call it without a circular
+// import. No GraphQL, no Linear writes — just labels + `blockedBy`.
+
+import { type DepNode, topoSort } from "../dep-graph/index.ts";
+import type { SubIssue } from "../linear/index.ts";
+
+const READY_FOR_AGENT = "ready-for-agent";
+const READY_FOR_HUMAN = "ready-for-human";
+const TERMINAL_STATE_TYPES = new Set(["completed", "canceled"]);
+
+export interface OrderedSubIssue {
+  /** Linear UUID. */
+  id: string;
+  identifier: string;
+  title: string;
+}
+
+export type BuildOrderedQueueResult =
+  | { kind: "queue"; ordered: OrderedSubIssue[] }
+  | { kind: "standalone" }
+  | { kind: "error"; message: string };
+
+/**
+ * Pure: turn the picked PRD's direct sub-issues into an ordered queue.
+ *
+ * - Filters to direct children carrying the `ready-for-agent` label.
+ * - If the filtered set is empty, returns `kind: "standalone"` — the caller
+ *   treats the PRD itself as the unit of work.
+ * - Closed (terminal-state) direct-child blockers are treated as satisfied.
+ * - A `blockedBy` reference outside the picked PRD's children surfaces as
+ *   an error mirroring the GitHub-path message shape.
+ * - A cycle among open scoped sub-issues surfaces as a cycle error.
+ */
+export function buildOrderedQueue(
+  subIssues: readonly SubIssue[]
+): BuildOrderedQueueResult {
+  const inScope = subIssues.filter((s) => s.labels.includes(READY_FOR_AGENT));
+  if (inScope.length === 0) {
+    return { kind: "standalone" };
+  }
+  const closedAmongDirectChildren = new Map(
+    subIssues.map(
+      (s) => [s.identifier, TERMINAL_STATE_TYPES.has(s.stateType)] as const
+    )
+  );
+
+  const nodes: DepNode[] = inScope.map((s) => {
+    const filtered = s.blockedBy.filter(
+      // Drop blockers that are direct children in a terminal state — those
+      // are satisfied. Any other blocker either is an in-scope sub-issue
+      // (handled by topoSort) or surfaces as an external-blocker error.
+      (b) => closedAmongDirectChildren.get(b) !== true
+    );
+    return {
+      id: s.identifier,
+      blockedBy: filtered,
+      closed: TERMINAL_STATE_TYPES.has(s.stateType),
+    };
+  });
+
+  const result = topoSort(nodes);
+  if (!result.ok) {
+    if (result.error.kind === "external-blocker") {
+      const { issue, blocker } = result.error;
+      // The blocker is in the picked PRD's direct children iff it appears in
+      // `closedAmongDirectChildren` (which maps every direct child, not just
+      // in-scope ones). Distinguish "out-of-scope direct child" from "truly
+      // outside the PRD" so the message points at the right fix.
+      const blockerDirectChild = subIssues.find(
+        (s) => s.identifier === blocker
+      );
+      if (blockerDirectChild) {
+        const labelHint = blockerDirectChild.labels.includes(READY_FOR_HUMAN)
+          ? "carries `ready-for-human` (flagged for human review)"
+          : "is missing the `ready-for-agent` label";
+        return {
+          kind: "error",
+          message:
+            `Sub-issue ${issue} is blocked by ${blocker}, a direct child of the picked PRD that ${labelHint}.\n` +
+            `Resolve in Linear: re-add \`ready-for-agent\` to the blocker, remove the relationship, or close the blocker.`,
+        };
+      }
+      return {
+        kind: "error",
+        message:
+          `Sub-issue ${issue} is blocked by ${blocker}, which is open and outside the picked PRD's children.\n` +
+          `Resolve by closing the blocker, removing the relationship, or expanding scope.`,
+      };
+    }
+    const edges = result.error.edges
+      .map((e) => `  ${e.from} -> ${e.to}`)
+      .join("\n");
+    return {
+      kind: "error",
+      message:
+        `Dependency graph contains a cycle. Offending edges:\n${edges}\n\n` +
+        "Resolve by removing one of the `blocked by` relationships in Linear, then re-run.",
+    };
+  }
+
+  const byIdentifier = new Map(inScope.map((s) => [s.identifier, s]));
+  const ordered: OrderedSubIssue[] = [];
+  for (const id of result.order) {
+    const sub = byIdentifier.get(id);
+    if (!sub) continue;
+    ordered.push({ id: sub.id, identifier: sub.identifier, title: sub.title });
+  }
+  return { kind: "queue", ordered };
+}

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -57,14 +57,17 @@ import { log } from "@clack/prompts";
 import type { TideConfig } from "../config-loader/index.ts";
 import {
   fetchIssueContent as defaultFetchIssueContent,
+  fetchSubIssues as defaultFetchSubIssues,
   flipLabelToReadyForHuman as defaultFlipLabelToReadyForHuman,
   postComment as defaultPostComment,
   transitionToDone as defaultTransitionToDone,
   transitionToInProgress as defaultTransitionToInProgress,
   type LinearContext,
   type LinearIssueContent,
+  type SubIssue,
 } from "../linear/index.ts";
 import { buildPromptArgs } from "../prompt-args/index.ts";
+import { buildOrderedQueue } from "../queue-build/index.ts";
 import { readFinalAssistantMessage as defaultReadFinalAssistantMessage } from "../transcript-extract/index.ts";
 import {
   renderSummarizerPrompt,
@@ -216,6 +219,10 @@ export interface RunIssueQueueOptions {
    * `git push -u origin <branch>` on the host after every working-agent
    * iteration that produced commits. See ADR-0007. */
   shellRunner?: ShellRunner;
+  /** Test seam — defaults to `linear.fetchSubIssues`. Called at every
+   * iteration boundary on PRD roots to absorb mid-run additions. See
+   * ADR-0010. Standalone roots never call this. */
+  fetchSubIssues?: (ctx: LinearContext, prdId: string) => Promise<SubIssue[]>;
 }
 
 export interface RunIssueQueueResult {
@@ -227,6 +234,10 @@ export interface RunIssueQueueResult {
   // agent-FAIL). The queue continues past these; they don't count toward
   // `completed`.
   flipped: number;
+  // Every sub-issue the runner ran an iteration on, in run order — including
+  // ones absorbed by a mid-run queue rebuild. The CLI's PR-tail step renders
+  // the "Sub-issues addressed" block from this. See ADR-0010.
+  processed: OrderedIssue[];
   // The issue that aborted the loop on an infra failure, if any.
   abortedAt?: {
     identifier: string;
@@ -392,6 +403,122 @@ async function pushBranchToOrigin(
 }
 
 /**
+ * Parse the first Linear-identifier-shaped token (e.g. "ENG-12") out of a
+ * `buildOrderedQueue` error string, so the rebuild's warn-and-skip path
+ * knows which candidate to drop on the retry attempt. Both error shapes
+ * surface the offending Sub-issue's identifier first:
+ *   - external-blocker: `Sub-issue ENG-X is blocked by ENG-Y, ...`
+ *   - cycle:            `... Offending edges:\n  ENG-X -> ENG-Y\n  ...`
+ */
+const OFFENDING_IDENTIFIER_RE = /[A-Z][A-Z0-9]*-\d+/;
+function parseOffendingIdentifier(message: string): string | undefined {
+  const match = OFFENDING_IDENTIFIER_RE.exec(message);
+  return match?.[0];
+}
+
+/** Outcome of a single iteration-boundary queue rebuild. */
+type RebuildOutcome =
+  | { kind: "queue"; queue: OrderedIssue[] }
+  | { kind: "fetch-failed"; reason: string }
+  | { kind: "abort"; identifier: string; reason: string };
+
+/**
+ * Re-fetch the picked PRD's direct children and rebuild the topo-ordered
+ * queue. The fetch result is fed to `buildOrderedQueue` unmodified — its
+ * existing closed-blocker / external-blocker / cycle handling subsumes the
+ * "exclude already-handled identifiers" rule (handled-Done sub-issues come
+ * back as `stateType: "completed"` which drops them from the order;
+ * handled-flipped ones come back without `ready-for-agent` which excludes
+ * them from in-scope). The outer loop's `handled.has` guard at pick time
+ * is the belt-and-braces against any stale Linear view.
+ *
+ * Logs one `Picked up new sub-issue: <id> <title>` line per identifier
+ * that wasn't already announced (pre-flight or a prior rebuild).
+ *
+ * - `fetchSubIssues` exception → warn-and-continue: the caller keeps the
+ *   previous boundary's queue.
+ * - topo error → warn-and-skip: drop the parsed offending identifier from
+ *   the candidate set and retry once. If the retry also errors, the caller
+ *   aborts via the existing infra-failure path.
+ * - empty `ready-for-agent` set → empty queue (loop ends).
+ */
+async function rebuildQueueAtBoundary(args: {
+  linearCtx: LinearContext;
+  prdId: string;
+  fetchSubIssues: (ctx: LinearContext, prdId: string) => Promise<SubIssue[]>;
+  knownIdentifiers: Set<string>;
+}): Promise<RebuildOutcome> {
+  let subIssues: SubIssue[];
+  try {
+    subIssues = await args.fetchSubIssues(args.linearCtx, args.prdId);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { kind: "fetch-failed", reason: msg };
+  }
+
+  // Don't pre-filter `handled` identifiers from the candidate set:
+  //   - handled-Done sub-issues fetch back with `stateType: "completed"`,
+  //     which `buildOrderedQueue`'s `closedAmongDirectChildren` map drops
+  //     from any dependent's `blockedBy` (treating the blocker as
+  //     satisfied). A new arrival X with `blockedBy: [Done-sibling]`
+  //     resolves cleanly.
+  //   - handled-flipped sub-issues fetch back without `ready-for-agent`,
+  //     so `buildOrderedQueue`'s in-scope filter already excludes them. A
+  //     new arrival blocked by a flipped sibling surfaces as external-
+  //     blocker (warn-and-skip below) — exactly the desired behaviour.
+  // The runner's outer loop already guards re-running an identifier via
+  // its `handled.has` check at pick time, so the pre-filter is redundant
+  // and would silently break the topo-correctness for handled-Done
+  // dependents.
+  let dropped: Set<string> | undefined;
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const candidates =
+      dropped === undefined
+        ? subIssues
+        : subIssues.filter((s) => dropped?.has(s.identifier) !== true);
+    const result = buildOrderedQueue(candidates);
+    if (result.kind === "queue") {
+      const queue: OrderedIssue[] = result.ordered.map((o) => ({
+        id: o.id,
+        identifier: o.identifier,
+        title: o.title,
+      }));
+      for (const o of queue) {
+        if (!args.knownIdentifiers.has(o.identifier)) {
+          log.info(`Picked up new sub-issue: ${o.identifier} ${o.title}`);
+          args.knownIdentifiers.add(o.identifier);
+        }
+      }
+      return { kind: "queue", queue };
+    }
+    if (result.kind === "standalone") {
+      // No `ready-for-agent` direct children remain — every queued unit was
+      // either handled this run or had its label removed. Loop terminates.
+      return { kind: "queue", queue: [] };
+    }
+    const offending = parseOffendingIdentifier(result.message);
+    if (attempt === 0 && offending !== undefined) {
+      log.warn(
+        `Queue rebuild error involving ${offending} — skipping it and retrying. ${result.message}`
+      );
+      dropped = new Set([offending]);
+      continue;
+    }
+    return {
+      kind: "abort",
+      identifier: offending ?? "unknown",
+      reason: `queue rebuild failed after retry: ${result.message}`,
+    };
+  }
+  // Unreachable: the loop returns on every branch.
+  return {
+    kind: "abort",
+    identifier: "unknown",
+    reason: "queue rebuild exhausted retries",
+  };
+}
+
+/**
  * Build the path under `<repoRoot>/.tide/logs/` where one specific run's
  * log file lands. Sandcastle's default file path lives under
  * `.sandcastle/logs/` (which the host bridges to `.tide/logs/` via a
@@ -426,6 +553,7 @@ export async function runIssueQueue(
   } = options;
   const fetchIssueContentFn =
     options.fetchIssueContent ?? defaultFetchIssueContent;
+  const fetchSubIssuesFn = options.fetchSubIssues ?? defaultFetchSubIssues;
   const transitionToInProgressFn =
     options.transitionToInProgress ?? defaultTransitionToInProgress;
   const transitionToDoneFn =
@@ -483,8 +611,26 @@ export async function runIssueQueue(
 
   let completed = 0;
   let flipped = 0;
+  const processed: OrderedIssue[] = [];
+  // Identifiers of Sub-issues this run has transitioned to Done OR flipped
+  // to ready-for-human. Excluded from every queue rebuild (and from the
+  // initial pre-flight queue's pick on the first iteration).
+  const handled = new Set<string>();
+  // Identifiers tide has already announced — either via the pre-flight log
+  // ("PRD-rooted: N sub-issue(s)") or a prior boundary's "Picked up new
+  // sub-issue" line. Used to dedupe the absorption log so we don't re-claim
+  // an arrival each time it survives a rebuild.
+  const knownIdentifiers = new Set<string>(
+    orderedIssues.map((o) => o.identifier)
+  );
+  let currentQueue: OrderedIssue[] = [...orderedIssues];
+
   try {
-    for (const ordered of orderedIssues) {
+    for (;;) {
+      const ordered = currentQueue.find((o) => !handled.has(o.identifier));
+      if (ordered === undefined) {
+        break;
+      }
       log.info(`Starting ${ordered.identifier}: ${ordered.title}`);
 
       let issueContent: LinearIssueContent;
@@ -496,6 +642,7 @@ export async function runIssueQueue(
         return {
           completed,
           flipped,
+          processed,
           abortedAt: {
             identifier: ordered.identifier,
             reason: `fetch failed: ${msg}`,
@@ -516,6 +663,7 @@ export async function runIssueQueue(
         return {
           completed,
           flipped,
+          processed,
           abortedAt: {
             identifier: ordered.identifier,
             reason: `transition to In Progress failed: ${msg}`,
@@ -563,6 +711,7 @@ export async function runIssueQueue(
         return {
           completed,
           flipped,
+          processed,
           abortedAt: {
             identifier: ordered.identifier,
             reason: `run() threw: ${msg}`,
@@ -635,6 +784,7 @@ export async function runIssueQueue(
           return {
             completed,
             flipped,
+            processed,
             abortedAt: {
               identifier: ordered.identifier,
               reason: `label flip failed: ${msg}`,
@@ -649,6 +799,7 @@ export async function runIssueQueue(
           return {
             completed,
             flipped,
+            processed,
             abortedAt: {
               identifier: ordered.identifier,
               reason: `comment post failed: ${msg}`,
@@ -656,47 +807,84 @@ export async function runIssueQueue(
           };
         }
         flipped++;
-        continue;
+        handled.add(ordered.identifier);
+        processed.push(ordered);
+      } else {
+        // DONE signalled and committed.
+        //
+        // PRD roots: the queued unit is a Sub-issue; transition it to *Done*
+        // host-side so the user sees real-time per-iteration progress in
+        // Linear (ADR-0005). A failure here is an infra failure: queue aborts.
+        //
+        // Standalone roots: the queued unit is the Standalone Issue itself.
+        // Skip the host-side Done transition — the Standalone Issue stays at
+        // *In Progress* and the CLI orchestration layer's post-submission
+        // hook transitions it to *In Review* once the PR is opened. This
+        // prevents the misleading-state case where the parent claims Done
+        // before review.
+        if (root.kind === "prd") {
+          try {
+            await transitionToDoneFn(linearCtx, ordered.id);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            log.error(
+              `Failed to transition ${ordered.identifier} to Done: ${msg}`
+            );
+            return {
+              completed,
+              flipped,
+              processed,
+              abortedAt: {
+                identifier: ordered.identifier,
+                reason: `transition to Done failed: ${msg}`,
+              },
+            };
+          }
+        }
+
+        completed++;
+        handled.add(ordered.identifier);
+        processed.push(ordered);
+        log.success(
+          `${ordered.identifier} done (${String(result.commits.length)} commit(s))`
+        );
       }
 
-      // DONE signalled and committed.
-      //
-      // PRD roots: the queued unit is a Sub-issue; transition it to *Done*
-      // host-side so the user sees real-time per-iteration progress in
-      // Linear (ADR-0005). A failure here is an infra failure: queue aborts.
-      //
-      // Standalone roots: the queued unit is the Standalone Issue itself.
-      // Skip the host-side Done transition — the Standalone Issue stays at
-      // *In Progress* and the CLI orchestration layer's post-submission
-      // hook transitions it to *In Review* once the PR is opened. This
-      // prevents the misleading-state case where the parent claims Done
-      // before review.
+      // Iteration boundary (PRD roots only). Re-fetch the picked PRD's
+      // direct children, exclude already-handled identifiers, and rebuild
+      // the topo order — absorbing any Sub-issues the human added in
+      // Linear's UI mid-run. Standalone Issue roots have no children and no
+      // boundary. See ADR-0010.
       if (root.kind === "prd") {
-        try {
-          await transitionToDoneFn(linearCtx, ordered.id);
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          log.error(
-            `Failed to transition ${ordered.identifier} to Done: ${msg}`
+        const outcome = await rebuildQueueAtBoundary({
+          linearCtx,
+          prdId: root.id,
+          fetchSubIssues: fetchSubIssuesFn,
+          knownIdentifiers,
+        });
+        if (outcome.kind === "queue") {
+          currentQueue = outcome.queue;
+        } else if (outcome.kind === "fetch-failed") {
+          log.warn(
+            `fetchSubIssues failed mid-run: ${outcome.reason} — continuing with previous queue`
           );
+          // Keep `currentQueue` unchanged; next boundary's call retries.
+        } else {
+          log.error(`Aborting after queue rebuild error: ${outcome.reason}`);
           return {
             completed,
             flipped,
+            processed,
             abortedAt: {
-              identifier: ordered.identifier,
-              reason: `transition to Done failed: ${msg}`,
+              identifier: outcome.identifier,
+              reason: outcome.reason,
             },
           };
         }
       }
-
-      completed++;
-      log.success(
-        `${ordered.identifier} done (${String(result.commits.length)} commit(s))`
-      );
     }
 
-    return { completed, flipped };
+    return { completed, flipped, processed };
   } finally {
     if (sandbox !== undefined) {
       await sandbox.close().catch(() => {

--- a/src/runner/runner.test.ts
+++ b/src/runner/runner.test.ts
@@ -21,7 +21,30 @@ import {
   type ShellRunner,
 } from "./index.ts";
 import type { TideConfig } from "../config-loader/index.ts";
-import type { LinearContext, LinearIssueContent } from "../linear/index.ts";
+import type {
+  LinearContext,
+  LinearIssueContent,
+  SubIssue,
+} from "../linear/index.ts";
+
+/**
+ * Map a runner's `OrderedIssue[]` into the `SubIssue[]` shape that
+ * `fetchSubIssues` returns, with `ready-for-agent` labels and no blockers.
+ * Used by tests to seed the per-boundary queue rebuild (ADR-0010) so
+ * iteration ≥2 has the same candidate set as the pre-flight queue. Tests
+ * that only need a single iteration can simply pass `() => []`.
+ */
+function asSubIssues(orderedIssues: OrderedIssue[]): SubIssue[] {
+  return orderedIssues.map((o) => ({
+    id: o.id,
+    identifier: o.identifier,
+    title: o.title,
+    state: "Backlog",
+    stateType: "backlog",
+    labels: ["ready-for-agent"],
+    blockedBy: [],
+  }));
+}
 
 interface ShellCall {
   cmd: string;
@@ -95,6 +118,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => {
         events.push("fetchContent");
         return Promise.resolve(makeIssueContent());
@@ -144,6 +168,13 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () =>
+        Promise.resolve(
+          asSubIssues([
+            makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
+            makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),
+          ])
+        ),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: (_ctx, issueId) => {
         events.push(`inProgress:${issueId}`);
@@ -250,6 +281,13 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () =>
+        Promise.resolve(
+          asSubIssues([
+            makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
+            makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),
+          ])
+        ),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: (_ctx, issueId) => {
         events.push(`inProgress:${issueId}`);
@@ -344,6 +382,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
       transitionToDone: () => Promise.resolve(),
@@ -378,6 +417,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => {
         events.push("inProgress");
@@ -441,6 +481,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => {
         events.push("inProgress");
@@ -503,6 +544,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
       transitionToDone: () => Promise.resolve(),
@@ -552,6 +594,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
       transitionToDone: () => Promise.resolve(),
@@ -605,6 +648,13 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () =>
+        Promise.resolve(
+          asSubIssues([
+            makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
+            makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),
+          ])
+        ),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
       transitionToDone: () => Promise.resolve(),
@@ -661,6 +711,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => {
         events.push("inProgress");
@@ -694,6 +745,13 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () =>
+        Promise.resolve(
+          asSubIssues([
+            makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
+            makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),
+          ])
+        ),
       fetchIssueContent: (_ctx, issueId) =>
         Promise.resolve(makeIssueContent({ identifier: issueId })),
       transitionToInProgress: (_ctx, issueId) => {
@@ -738,6 +796,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: (_ctx, issueId) => {
         inProgressCalls.push(issueId);
@@ -768,6 +827,7 @@ describe("runIssueQueue — prompt args + sandcastle wiring", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () =>
         Promise.resolve(makeIssueContent({ identifier: "ENG-7" })),
       transitionToInProgress: () => Promise.resolve(),
@@ -807,6 +867,7 @@ describe("runIssueQueue — prompt args + sandcastle wiring", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
       transitionToDone: () => Promise.resolve(),
@@ -838,6 +899,7 @@ describe("runIssueQueue — prompt args + sandcastle wiring", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
       transitionToDone: () => {
@@ -895,6 +957,7 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
       transitionToDone: () => Promise.resolve(),
@@ -921,6 +984,7 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
       transitionToDone: () => Promise.resolve(),
@@ -968,6 +1032,7 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
       transitionToDone: () => Promise.resolve(),
@@ -1006,6 +1071,13 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () =>
+        Promise.resolve(
+          asSubIssues([
+            makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
+            makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),
+          ])
+        ),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: (_ctx, issueId) => {
         events.push(`inProgress:${issueId}`);
@@ -1161,6 +1233,7 @@ describe("runIssueQueue — Standalone Issue root: skip Done transition", () => 
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
       transitionToDone: (_ctx, issueId) => {
@@ -1173,5 +1246,554 @@ describe("runIssueQueue — Standalone Issue root: skip Done transition", () => 
     // Sub-issues continue to transition to Done host-side (real-time
     // per-iteration progress, ADR-0005).
     expect(doneCalls).toEqual(["uuid-sub-1"]);
+  });
+});
+
+describe("runIssueQueue — mid-run queue rebuild (ADR-0010)", () => {
+  test("PRD root: result.processed lists every sub-issue the runner ran an iteration on, in run order", async () => {
+    const result = await runIssueQueue({
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
+      orderedIssues: [
+        makeOrdered({ id: "uuid-1", identifier: "ENG-1", title: "First" }),
+        makeOrdered({ id: "uuid-2", identifier: "ENG-2", title: "Second" }),
+      ],
+      branch: "feature/eng",
+      baseBranch: "master",
+      linearCtx,
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () =>
+        Promise.resolve(
+          asSubIssues([
+            makeOrdered({ id: "uuid-1", identifier: "ENG-1", title: "First" }),
+            makeOrdered({
+              id: "uuid-2",
+              identifier: "ENG-2",
+              title: "Second",
+            }),
+          ])
+        ),
+      fetchIssueContent: (_ctx, issueId) =>
+        Promise.resolve(makeIssueContent({ identifier: issueId })),
+      transitionToInProgress: () => Promise.resolve(),
+      transitionToDone: () => Promise.resolve(),
+      sandboxRun: () => Promise.resolve(makeSandboxRunResult()),
+    });
+
+    expect(result.processed.map((o) => o.identifier)).toEqual([
+      "ENG-1",
+      "ENG-2",
+    ]);
+  });
+
+  test("PRD root: human adds a fresh ready-for-agent sub-issue mid-run; it is absorbed and runs after the snapshot drains", async () => {
+    const events: string[] = [];
+    let fetchCount = 0;
+
+    const result = await runIssueQueue({
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
+      orderedIssues: [
+        makeOrdered({ id: "uuid-1", identifier: "ENG-1", title: "First" }),
+      ],
+      branch: "feature/eng",
+      baseBranch: "master",
+      linearCtx,
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => {
+        fetchCount += 1;
+        // After iteration 1, the human added ENG-2 in Linear's UI.
+        if (fetchCount === 1) {
+          return Promise.resolve(
+            asSubIssues([
+              makeOrdered({
+                id: "uuid-1",
+                identifier: "ENG-1",
+                title: "First",
+              }),
+              makeOrdered({
+                id: "uuid-2",
+                identifier: "ENG-2",
+                title: "Late arrival",
+              }),
+            ])
+          );
+        }
+        return Promise.resolve([]);
+      },
+      fetchIssueContent: (_ctx, issueId) => {
+        events.push(`fetch:${issueId}`);
+        return Promise.resolve(makeIssueContent({ identifier: issueId }));
+      },
+      transitionToInProgress: (_ctx, issueId) => {
+        events.push(`inProgress:${issueId}`);
+        return Promise.resolve();
+      },
+      transitionToDone: (_ctx, issueId) => {
+        events.push(`done:${issueId}`);
+        return Promise.resolve();
+      },
+      sandboxRun: () => {
+        events.push("run");
+        return Promise.resolve(makeSandboxRunResult());
+      },
+    });
+
+    expect(result.completed).toBe(2);
+    expect(result.flipped).toBe(0);
+    expect(result.abortedAt).toBeUndefined();
+    expect(result.processed.map((o) => o.identifier)).toEqual([
+      "ENG-1",
+      "ENG-2",
+    ]);
+    // Iteration 1 ran ENG-1 → boundary fetch absorbed ENG-2 → iteration 2 ran ENG-2.
+    expect(events).toContain("inProgress:uuid-1");
+    expect(events).toContain("done:uuid-1");
+    expect(events).toContain("inProgress:uuid-2");
+    expect(events).toContain("done:uuid-2");
+  });
+
+  test("PRD root: late arrival X with blockedBy → still-queued Y runs Y first regardless of arrival order", async () => {
+    const events: string[] = [];
+    let fetchCount = 0;
+
+    // Initial queue has only ENG-1 (Y) — the human will add ENG-2 (X)
+    // mid-run with blockedBy: ["ENG-1"]. The rebuild should re-topo-sort,
+    // but ENG-1 is in `handled` after iteration 1, so only ENG-2 remains
+    // and runs next.
+    const result = await runIssueQueue({
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
+      orderedIssues: [
+        makeOrdered({ id: "uuid-1", identifier: "ENG-1", title: "Y first" }),
+      ],
+      branch: "feature/eng",
+      baseBranch: "master",
+      linearCtx,
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => {
+        fetchCount += 1;
+        if (fetchCount === 1) {
+          // Boundary 1: ENG-2 (X) shows up with blockedBy ENG-1 (Y).
+          return Promise.resolve([
+            ...asSubIssues([
+              makeOrdered({
+                id: "uuid-1",
+                identifier: "ENG-1",
+                title: "Y first",
+              }),
+            ]),
+            {
+              id: "uuid-2",
+              identifier: "ENG-2",
+              title: "X depends on Y",
+              state: "Backlog",
+              stateType: "backlog",
+              labels: ["ready-for-agent"],
+              blockedBy: ["ENG-1"],
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      },
+      fetchIssueContent: (_ctx, issueId) => {
+        events.push(`fetch:${issueId}`);
+        return Promise.resolve(makeIssueContent({ identifier: issueId }));
+      },
+      transitionToInProgress: (_ctx, issueId) => {
+        events.push(`inProgress:${issueId}`);
+        return Promise.resolve();
+      },
+      transitionToDone: (_ctx, issueId) => {
+        events.push(`done:${issueId}`);
+        return Promise.resolve();
+      },
+      sandboxRun: () => Promise.resolve(makeSandboxRunResult()),
+    });
+
+    // Y ran first (it was the snapshot's only entry), then X was absorbed
+    // and ran after — topo-correct because ENG-1 was already handled when
+    // the rebuild fired, so the buildOrderedQueue's external-blocker check
+    // never triggers (a handled identifier is filtered out before the
+    // dep-graph sees it).
+    expect(result.processed.map((o) => o.identifier)).toEqual([
+      "ENG-1",
+      "ENG-2",
+    ]);
+    expect(events).toEqual([
+      "fetch:uuid-prd", // parent PRD body fetch
+      "fetch:uuid-1",
+      "inProgress:uuid-1",
+      "done:uuid-1",
+      "fetch:uuid-2",
+      "inProgress:uuid-2",
+      "done:uuid-2",
+    ]);
+  });
+
+  test("PRD root: late arrival X with blockedBy → already-flipped sibling errors as external-blocker; X is skipped, the rest of the queue continues", async () => {
+    let fetchCount = 0;
+    let runCount = 0;
+
+    const result = await runIssueQueue({
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
+      orderedIssues: [
+        makeOrdered({ id: "uuid-1", identifier: "ENG-1", title: "First" }),
+        makeOrdered({ id: "uuid-2", identifier: "ENG-2", title: "Second" }),
+      ],
+      branch: "feature/eng",
+      baseBranch: "master",
+      linearCtx,
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => {
+        fetchCount += 1;
+        if (fetchCount === 1) {
+          // After iteration 1: ENG-1 was just flipped (BLOCKED). The
+          // human added ENG-3 with blockedBy ENG-1 — but tide flipped
+          // ENG-1 to ready-for-human, so the rebuild must reject ENG-3.
+          // ENG-2 is still ready-for-agent and should still run.
+          return Promise.resolve([
+            // ENG-1 lost its `ready-for-agent` (now `ready-for-human`).
+            {
+              id: "uuid-1",
+              identifier: "ENG-1",
+              title: "First",
+              state: "In Progress",
+              stateType: "started",
+              labels: ["ready-for-human"],
+              blockedBy: [],
+            },
+            ...asSubIssues([
+              makeOrdered({
+                id: "uuid-2",
+                identifier: "ENG-2",
+                title: "Second",
+              }),
+            ]),
+            {
+              id: "uuid-3",
+              identifier: "ENG-3",
+              title: "Late arrival blocked by flipped",
+              state: "Backlog",
+              stateType: "backlog",
+              labels: ["ready-for-agent"],
+              blockedBy: ["ENG-1"],
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      },
+      fetchIssueContent: () => Promise.resolve(makeIssueContent()),
+      transitionToInProgress: () => Promise.resolve(),
+      transitionToDone: () => Promise.resolve(),
+      flipLabelToReadyForHuman: () => Promise.resolve(),
+      postComment: () => Promise.resolve(),
+      sandboxRun: (opts: SandboxRunOptions) => {
+        if (opts.name === "tide-summarizer") {
+          return Promise.resolve(
+            makeSandboxRunResult({
+              commits: [],
+              completionSignal: undefined,
+              logFilePath: "/tmp/summary.log",
+            })
+          );
+        }
+        runCount += 1;
+        // Iteration 1 (working ENG-1): BLOCKED to set up the flipped
+        // sibling for the rebuild's external-blocker error. Iteration 2
+        // (working ENG-2): clean success.
+        if (runCount === 1) {
+          return Promise.resolve(
+            makeSandboxRunResult({
+              commits: [],
+              completionSignal: BLOCKED_SIGNAL,
+              logFilePath: "/tmp/eng-1.log",
+            })
+          );
+        }
+        return Promise.resolve(makeSandboxRunResult());
+      },
+      readFinalAssistantMessage: () =>
+        Promise.resolve("summarized comment body"),
+    });
+
+    expect(result.abortedAt).toBeUndefined();
+    expect(result.flipped).toBe(1);
+    expect(result.completed).toBe(1);
+    // ENG-3 was skipped (warn-and-skip). ENG-2 ran cleanly after the rebuild.
+    expect(result.processed.map((o) => o.identifier)).toEqual([
+      "ENG-1",
+      "ENG-2",
+    ]);
+  });
+
+  test("PRD root: rebuild error survives the retry → tide aborts via the existing infra-failure path", async () => {
+    let fetchCount = 0;
+
+    const result = await runIssueQueue({
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
+      orderedIssues: [
+        makeOrdered({ id: "uuid-1", identifier: "ENG-1", title: "First" }),
+        makeOrdered({ id: "uuid-2", identifier: "ENG-2", title: "Second" }),
+      ],
+      branch: "feature/eng",
+      baseBranch: "master",
+      linearCtx,
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => {
+        fetchCount += 1;
+        // After iteration 1: ENG-2 has acquired a blockedBy that points to
+        // an external (out-of-PRD) identifier. Dropping ENG-2 from
+        // candidates leaves the queue empty, but the parser surfaces the
+        // identifier and the second pass succeeds — so we engineer a
+        // case that fails BOTH passes: ENG-2 is blocked by ENG-99
+        // (external), AND we add a second still-bad node ENG-3 also
+        // blocked by ENG-99. Dropping just one isn't enough.
+        if (fetchCount === 1) {
+          return Promise.resolve([
+            {
+              id: "uuid-2",
+              identifier: "ENG-2",
+              title: "Second",
+              state: "Backlog",
+              stateType: "backlog",
+              labels: ["ready-for-agent"],
+              blockedBy: ["ENG-99"],
+            },
+            {
+              id: "uuid-3",
+              identifier: "ENG-3",
+              title: "Third",
+              state: "Backlog",
+              stateType: "backlog",
+              labels: ["ready-for-agent"],
+              blockedBy: ["ENG-99"],
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      },
+      fetchIssueContent: (_ctx, issueId) =>
+        Promise.resolve(makeIssueContent({ identifier: issueId })),
+      transitionToInProgress: () => Promise.resolve(),
+      transitionToDone: () => Promise.resolve(),
+      sandboxRun: () => Promise.resolve(makeSandboxRunResult()),
+    });
+
+    expect(result.abortedAt).toBeDefined();
+    expect(result.abortedAt?.identifier).toMatch(/^ENG-/);
+    expect(result.abortedAt?.reason).toContain("queue rebuild failed");
+    // ENG-1 ran cleanly before the abort.
+    expect(result.completed).toBe(1);
+    expect(result.processed.map((o) => o.identifier)).toEqual(["ENG-1"]);
+  });
+
+  test("PRD root: fetchSubIssues throws mid-run → warn-and-continue with the previous boundary's queue", async () => {
+    let fetchCount = 0;
+    const events: string[] = [];
+
+    const result = await runIssueQueue({
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
+      orderedIssues: [
+        makeOrdered({ id: "uuid-1", identifier: "ENG-1", title: "First" }),
+        makeOrdered({ id: "uuid-2", identifier: "ENG-2", title: "Second" }),
+      ],
+      branch: "feature/eng",
+      baseBranch: "master",
+      linearCtx,
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => {
+        fetchCount += 1;
+        if (fetchCount === 1) {
+          return Promise.reject(new Error("Linear API hiccup"));
+        }
+        return Promise.resolve([]);
+      },
+      fetchIssueContent: (_ctx, issueId) => {
+        events.push(`fetch:${issueId}`);
+        return Promise.resolve(makeIssueContent({ identifier: issueId }));
+      },
+      transitionToInProgress: (_ctx, issueId) => {
+        events.push(`inProgress:${issueId}`);
+        return Promise.resolve();
+      },
+      transitionToDone: (_ctx, issueId) => {
+        events.push(`done:${issueId}`);
+        return Promise.resolve();
+      },
+      sandboxRun: () => Promise.resolve(makeSandboxRunResult()),
+    });
+
+    // ENG-2 still ran because the rebuild fell back to the previous queue.
+    expect(result.abortedAt).toBeUndefined();
+    expect(result.completed).toBe(2);
+    expect(result.processed.map((o) => o.identifier)).toEqual([
+      "ENG-1",
+      "ENG-2",
+    ]);
+  });
+
+  test("PRD root: queued-but-not-yet-run sub-issue loses ready-for-agent mid-run → silently dropped on next rebuild", async () => {
+    let fetchCount = 0;
+
+    const result = await runIssueQueue({
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
+      orderedIssues: [
+        makeOrdered({ id: "uuid-1", identifier: "ENG-1", title: "First" }),
+        makeOrdered({ id: "uuid-2", identifier: "ENG-2", title: "Second" }),
+      ],
+      branch: "feature/eng",
+      baseBranch: "master",
+      linearCtx,
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => {
+        fetchCount += 1;
+        if (fetchCount === 1) {
+          // Human removed `ready-for-agent` from ENG-2 mid-run.
+          return Promise.resolve([
+            ...asSubIssues([
+              makeOrdered({
+                id: "uuid-1",
+                identifier: "ENG-1",
+                title: "First",
+              }),
+            ]),
+            {
+              id: "uuid-2",
+              identifier: "ENG-2",
+              title: "Second",
+              state: "Backlog",
+              stateType: "backlog",
+              labels: [],
+              blockedBy: [],
+            },
+          ]);
+        }
+        return Promise.resolve([]);
+      },
+      fetchIssueContent: (_ctx, issueId) =>
+        Promise.resolve(makeIssueContent({ identifier: issueId })),
+      transitionToInProgress: () => Promise.resolve(),
+      transitionToDone: () => Promise.resolve(),
+      sandboxRun: () => Promise.resolve(makeSandboxRunResult()),
+    });
+
+    expect(result.abortedAt).toBeUndefined();
+    expect(result.completed).toBe(1);
+    expect(result.processed.map((o) => o.identifier)).toEqual(["ENG-1"]);
+  });
+
+  test("Standalone Issue root: never calls fetchSubIssues — the rebuild path is skipped entirely", async () => {
+    let fetchCalls = 0;
+
+    const result = await runIssueQueue({
+      root: { kind: "standalone" },
+      orderedIssues: [makeOrdered({ id: "uuid-iss-7", identifier: "ENG-7" })],
+      branch: "feature/eng-7",
+      baseBranch: "master",
+      linearCtx,
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => {
+        fetchCalls += 1;
+        return Promise.resolve([]);
+      },
+      fetchIssueContent: () => Promise.resolve(makeIssueContent()),
+      transitionToInProgress: () => Promise.resolve(),
+      transitionToDone: () => Promise.resolve(),
+      sandboxRun: () => Promise.resolve(makeSandboxRunResult()),
+    });
+
+    expect(fetchCalls).toBe(0);
+    expect(result.processed).toHaveLength(1);
+    expect(result.processed[0]?.identifier).toBe("ENG-7");
+  });
+
+  test("PRD root: an absorbed sub-issue that BLOCKEDs appears in `processed` and counts toward `flipped`", async () => {
+    let runCount = 0;
+    let fetchCount = 0;
+
+    const result = await runIssueQueue({
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
+      orderedIssues: [
+        makeOrdered({ id: "uuid-1", identifier: "ENG-1", title: "First" }),
+      ],
+      branch: "feature/eng",
+      baseBranch: "master",
+      linearCtx,
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: () => {
+        fetchCount += 1;
+        if (fetchCount === 1) {
+          return Promise.resolve(
+            asSubIssues([
+              makeOrdered({
+                id: "uuid-1",
+                identifier: "ENG-1",
+                title: "First",
+              }),
+              makeOrdered({
+                id: "uuid-2",
+                identifier: "ENG-2",
+                title: "Late",
+              }),
+            ])
+          );
+        }
+        return Promise.resolve([]);
+      },
+      fetchIssueContent: (_ctx, issueId) =>
+        Promise.resolve(makeIssueContent({ identifier: issueId })),
+      transitionToInProgress: () => Promise.resolve(),
+      transitionToDone: () => Promise.resolve(),
+      flipLabelToReadyForHuman: () => Promise.resolve(),
+      postComment: () => Promise.resolve(),
+      sandboxRun: (opts: SandboxRunOptions) => {
+        runCount += 1;
+        // Iteration 1 (working): ENG-1 succeeds. Iteration 2 (working):
+        // ENG-2 BLOCKEDs. Iteration 3 (summarizer for ENG-2).
+        if (opts.name === "tide-summarizer") {
+          return Promise.resolve(
+            makeSandboxRunResult({
+              commits: [],
+              completionSignal: undefined,
+              logFilePath: "/tmp/eng-2-summary.log",
+            })
+          );
+        }
+        if (runCount === 1) {
+          return Promise.resolve(makeSandboxRunResult());
+        }
+        return Promise.resolve(
+          makeSandboxRunResult({
+            commits: [],
+            completionSignal: BLOCKED_SIGNAL,
+            logFilePath: "/tmp/eng-2-working.log",
+          })
+        );
+      },
+      readFinalAssistantMessage: () => Promise.resolve("summary"),
+    });
+
+    expect(result.completed).toBe(1);
+    expect(result.flipped).toBe(1);
+    expect(result.processed.map((o) => o.identifier)).toEqual([
+      "ENG-1",
+      "ENG-2",
+    ]);
   });
 });


### PR DESCRIPTION
## 🚩 The Problem

* `tide run` snapshots the PRD's sub-issue queue once at pre-flight, so Sub-issues humans add mid-run never get picked up.
* Sub-issues whose `ready-for-agent` label is removed mid-run still execute, because the snapshot ignores live label state.
* The PR-tail's "Sub-issues addressed" list is built from the pre-flight snapshot, so absorbed-mid-run work never appears in the PR body.

## 💡 The Solution

* At every iteration boundary on PRD roots, re-fetch the picked PRD's direct children and rebuild the topo-ordered queue (ADR-0010).
* Carve `buildOrderedQueue` out of `cli/run.ts` into a new `queue-build` package so both pre-flight and mid-run callers share the same pure ordering logic without a circular import.
* Return the actually-processed list (initial + absorbed) from the runner so the PR-tail renders what actually ran, not what was originally planned.
* Fetch failures warn-and-continue with the previous queue; topo errors involving fresh arrivals warn-and-skip with a single retry; Standalone roots skip the whole rebuild.

## 🏗 Architecture & Public Interface Changes

### 🗺 Interface Movements

| Interface / Symbol | Old Location / Status | New Location / Status | Notes |
| :--- | :--- | :--- | :--- |
| `buildOrderedQueue` | `cli/run` | `queue-build` | Extracted; re-exported from `cli/run` for callers. |
| `BuildOrderedQueueResult` | `cli/run` | `queue-build` | Same — extracted, re-exported. |
| `OrderedSubIssue` | `cli/run` | `queue-build` | Same — extracted, re-exported. |
| `RunIssueQueueResult.processed` | 🚫 absent | 🌐 Public | New required field: every Sub-issue an iteration ran on, in run order. |
| `RunIssueQueueOptions.fetchSubIssues` | 🚫 absent | 🌐 Public (optional) | Test seam for the per-iteration rebuild; defaults to `linear.fetchSubIssues`. |

### 📦 Package Breakdowns

#### 1. `src/queue-build` (new)

*Pure topo-ordering of a PRD's direct sub-issues. Carved out of `cli/run` so both the pre-flight queue build and the runner's per-iteration rebuild can call it without a circular import. No GraphQL, no Linear writes.*

<details>
<summary>🔍 View Interface Changes</summary>

```diff
+ export interface OrderedSubIssue {
+   id: string
+   identifier: string
+   title: string
+ }

+ export type BuildOrderedQueueResult =
+   | { kind: "queue"; ordered: OrderedSubIssue[] }
+   | { kind: "standalone" }
+   | { kind: "error"; message: string }

+ export function buildOrderedQueue(subIssues: readonly SubIssue[]): BuildOrderedQueueResult
```
</details>

<sub>**Files changed:** [`index.ts`](https://github.com/m1yon/tide/pull/38/files#diff-c2a102ba8c315f5b5c925230ed0793d32977effc95eb353650fda5071626a0f9)</sub>

---

#### 2. `src/runner`

*PRD roots now rebuild the ordered queue at every iteration boundary, absorbing human-added Sub-issues and dropping ones whose `ready-for-agent` label was removed. The runner reports back exactly which Sub-issues it ran. Standalone roots are unchanged — no parent, no rebuild.*

<details>
<summary>🔍 View Interface Changes</summary>

```diff
  export interface RunIssueQueueOptions {
    ...
+   fetchSubIssues?: (ctx: LinearContext, prdId: string) => Promise<SubIssue[]>
  }

  export interface RunIssueQueueResult {
    completed: number
    flipped: number
+   processed: OrderedIssue[]
    abortedAt?: { identifier: string; reason: string; preservedWorktreePath?: string }
  }
```
</details>

<sub>**Files changed:** [`index.ts`](https://github.com/m1yon/tide/pull/38/files#diff-f4fca321dfe1b7cef6d23aac42007fa502578ea54f72e32ceaaa9a8a00f7f782), [`runner.test.ts`](https://github.com/m1yon/tide/pull/38/files#diff-5fe4b6f0911108e658dfb15ea493e2b611cabc4040bc31c5a7926b8be751a5a3)</sub>

---

#### 3. `src/cli/run`

*The `buildOrderedQueue` chunk moved out to `queue-build` (re-exported for backwards-compat). The PR-tail's "Sub-issues addressed" block is now built from `queueResult.processed` instead of the pre-flight snapshot, so mid-run absorptions appear in the PR body.*

<details>
<summary>🔍 View Interface Changes</summary>

```diff
- export function buildOrderedQueue(subIssues: readonly SubIssue[]): BuildOrderedQueueResult
- export interface OrderedSubIssue { ... }
- export type BuildOrderedQueueResult = ...

+ export { buildOrderedQueue }
+ export type { BuildOrderedQueueResult, OrderedSubIssue }

  // PR-tail "Sub-issues addressed" source:
- subIssueRefs: orderedIssues.map(...)
+ subIssueRefs: queueResult.processed.map(...)
```
</details>

<sub>**Files changed:** [`run.ts`](https://github.com/m1yon/tide/pull/38/files#diff-dfa9baf011a9c38263c91af5d92745dd686bcc12a41d4974257c98da689589df), [`run.test.ts`](https://github.com/m1yon/tide/pull/38/files#diff-8ddf6e9a622d2440af27fb802251e7b9b9c1468385aee7f8a8c292ba90a7192d)</sub>

## 🧹 Housekeeping & Secondary Changes

* Drops the local `READY_FOR_AGENT` / `TERMINAL_STATE_TYPES` constants and `dep-graph` import from `cli/run` (now owned by `queue-build`).
* Adds runner-side `parseOffendingIdentifier` helper to drive warn-and-skip-with-retry on rebuild topo errors.