### PR TITLE
feat: sandcastle bridge — repair in tide setup, detect in tide doctor

### DIFF
--- a/src/cli/doctor.test.ts
+++ b/src/cli/doctor.test.ts
@@ -1,8 +1,21 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { doctor, type Runner } from "./doctor.ts";
+import { doctor, type ClassifyBridgeFn, type Runner } from "./doctor.ts";
+import {
+  classifyBridge,
+  type BridgeState,
+} from "../sandcastle-bridge/index.ts";
 
 interface RunnerStub {
   // Map "<cmd> <args.joined-by-space>" → result
@@ -11,11 +24,14 @@ interface RunnerStub {
     { exitCode: number; stdout: string; stderr?: string }
   >;
   calls: { cmd: string; args: readonly string[]; cwd: string | undefined }[];
+  /** Optional shared call log for ordering assertions. */
+  orderLog?: string[];
 }
 
 function buildRunner(stub: RunnerStub): Runner {
   return (cmd, args, cwd) => {
     stub.calls.push({ cmd, args: [...args], cwd });
+    stub.orderLog?.push([cmd, ...args].join(" "));
     const key = [cmd, ...args].join(" ");
     const result = stub.responses[key];
     if (result === undefined) {
@@ -336,5 +352,190 @@ describe("tide doctor", () => {
     }
 
     expect(code).toBe(1);
+  });
+
+  describe("sandcastle bridge check", () => {
+    type WriteFn = typeof process.stdout.write;
+    let stdoutChunks: string[];
+    let stderrChunks: string[];
+    let originalStdoutWrite: WriteFn;
+    let originalStderrWrite: WriteFn;
+
+    beforeEach(() => {
+      stdoutChunks = [];
+      stderrChunks = [];
+      originalStdoutWrite = process.stdout.write.bind(process.stdout);
+      originalStderrWrite = process.stderr.write.bind(process.stderr);
+      const captureStdout: WriteFn = (chunk: string | Uint8Array): boolean => {
+        stdoutChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+        return true;
+      };
+      const captureStderr: WriteFn = (chunk: string | Uint8Array): boolean => {
+        stderrChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+        return true;
+      };
+      process.stdout.write = captureStdout;
+      process.stderr.write = captureStderr;
+    });
+
+    afterEach(() => {
+      process.stdout.write = originalStdoutWrite;
+      process.stderr.write = originalStderrWrite;
+    });
+
+    function allOutput(): string {
+      return stdoutChunks.join("") + stderrChunks.join("");
+    }
+
+    test("bridge check runs first — before any runner call", async () => {
+      writeValidEnv();
+      writeValidConfig();
+      const orderLog: string[] = [];
+      const stub: RunnerStub = { ...happyRunnerStub(), orderLog };
+      const classifyStub: ClassifyBridgeFn = (root) => {
+        orderLog.push(`classifyBridge:${root}`);
+        return classifyBridge(root);
+      };
+
+      const code = await doctor({
+        repoRoot,
+        runner: buildRunner(stub),
+        linearViewerCheck: () => Promise.resolve(),
+        linearInReviewStateCheck: () => Promise.resolve(),
+        classifyBridge: classifyStub,
+      });
+
+      expect(code).toBe(0);
+      expect(orderLog[0]).toBe(`classifyBridge:${repoRoot}`);
+      expect(orderLog.indexOf("gh auth status")).toBeGreaterThan(0);
+    });
+
+    test("intact bridge — passes the check", async () => {
+      writeValidEnv();
+      writeValidConfig();
+      symlinkSync(".tide", join(repoRoot, ".sandcastle"), "dir");
+
+      const code = await doctor({
+        repoRoot,
+        runner: buildRunner(happyRunnerStub()),
+        linearViewerCheck: () => Promise.resolve(),
+        linearInReviewStateCheck: () => Promise.resolve(),
+      });
+
+      expect(code).toBe(0);
+    });
+
+    test("missing bridge — passes the check", async () => {
+      writeValidEnv();
+      writeValidConfig();
+      // No `.sandcastle` entry created — classifyBridge returns `missing`.
+
+      const code = await doctor({
+        repoRoot,
+        runner: buildRunner(happyRunnerStub()),
+        linearViewerCheck: () => Promise.resolve(),
+        linearInReviewStateCheck: () => Promise.resolve(),
+      });
+
+      expect(code).toBe(0);
+    });
+
+    const brokenStates: {
+      name: string;
+      kind: BridgeState["kind"];
+      setup: () => void;
+    }[] = [
+      {
+        name: "wrong-symlink-target",
+        kind: "wrong-symlink-target",
+        setup: () => {
+          symlinkSync(
+            "some-other-target",
+            join(repoRoot, ".sandcastle"),
+            "dir"
+          );
+        },
+      },
+      {
+        name: "real-dir-empty",
+        kind: "real-dir-empty",
+        setup: () => {
+          mkdirSync(join(repoRoot, ".sandcastle"));
+          mkdirSync(join(repoRoot, ".sandcastle", "worktrees"));
+        },
+      },
+      {
+        name: "real-dir-with-content",
+        kind: "real-dir-with-content",
+        setup: () => {
+          mkdirSync(join(repoRoot, ".sandcastle"));
+          writeFileSync(join(repoRoot, ".sandcastle", "junk.log"), "x\n");
+        },
+      },
+      {
+        name: "regular-file",
+        kind: "regular-file",
+        setup: () => {
+          writeFileSync(join(repoRoot, ".sandcastle"), "junk\n");
+        },
+      },
+    ];
+
+    for (const broken of brokenStates) {
+      test(`broken bridge (${broken.name}) — FAILs and the hint mentions \`tide setup\``, async () => {
+        writeValidEnv();
+        writeValidConfig();
+        broken.setup();
+
+        const code = await doctor({
+          repoRoot,
+          runner: buildRunner(happyRunnerStub()),
+          linearViewerCheck: () => Promise.resolve(),
+          linearInReviewStateCheck: () => Promise.resolve(),
+        });
+
+        expect(code).toBe(1);
+        expect(allOutput()).toContain("tide setup");
+        // Read-only invariant: doctor must not modify the bridge state.
+        expect(classifyBridge(repoRoot).kind).toBe(broken.kind);
+      });
+    }
+
+    test("read-only — broken `real-dir-with-content` left untouched on disk", async () => {
+      writeValidEnv();
+      writeValidConfig();
+      mkdirSync(join(repoRoot, ".sandcastle"));
+      writeFileSync(join(repoRoot, ".sandcastle", "log.txt"), "preserve me\n");
+      const before = readdirSync(join(repoRoot, ".sandcastle"));
+
+      await doctor({
+        repoRoot,
+        runner: buildRunner(happyRunnerStub()),
+        linearViewerCheck: () => Promise.resolve(),
+        linearInReviewStateCheck: () => Promise.resolve(),
+      });
+
+      const stat = lstatSync(join(repoRoot, ".sandcastle"));
+      expect(stat.isSymbolicLink()).toBe(false);
+      expect(stat.isDirectory()).toBe(true);
+      expect(readdirSync(join(repoRoot, ".sandcastle"))).toEqual(before);
+    });
+
+    test("read-only — broken `wrong-symlink-target` symlink left untouched", async () => {
+      writeValidEnv();
+      writeValidConfig();
+      symlinkSync("some-other-target", join(repoRoot, ".sandcastle"), "dir");
+
+      await doctor({
+        repoRoot,
+        runner: buildRunner(happyRunnerStub()),
+        linearViewerCheck: () => Promise.resolve(),
+        linearInReviewStateCheck: () => Promise.resolve(),
+      });
+
+      expect(readlinkSync(join(repoRoot, ".sandcastle"))).toBe(
+        "some-other-target"
+      );
+    });
   });
 });

--- a/src/cli/doctor.test.ts
+++ b/src/cli/doctor.test.ts
@@ -29,34 +29,6 @@ function buildRunner(stub: RunnerStub): Runner {
   };
 }
 
-interface Sinks {
-  stdout: string[];
-  stderr: string[];
-  pushStdout: (s: string) => void;
-  pushStderr: (s: string) => void;
-}
-
-function makeSinks(): Sinks {
-  const sinks: Sinks = {
-    stdout: [],
-    stderr: [],
-    pushStdout: (s: string) => {
-      // assigned below
-      void s;
-    },
-    pushStderr: (s: string) => {
-      void s;
-    },
-  };
-  sinks.pushStdout = (s: string) => {
-    sinks.stdout.push(s);
-  };
-  sinks.pushStderr = (s: string) => {
-    sinks.stderr.push(s);
-  };
-  return sinks;
-}
-
 describe("tide doctor", () => {
   let workDir: string;
   let repoRoot: string;
@@ -88,8 +60,8 @@ describe("tide doctor", () => {
     );
   }
 
-  function happyRunner(): Runner {
-    return buildRunner({
+  function happyRunnerStub(): RunnerStub {
+    return {
       calls: [],
       responses: {
         "gh auth status": { exitCode: 0, stdout: "" },
@@ -99,34 +71,36 @@ describe("tide doctor", () => {
           stdout: JSON.stringify({ owner: { login: "m1yon" }, name: "tide" }),
         },
       },
-    });
+    };
   }
 
-  test("all checks pass — exits zero, prints version, prints all-passed line", async () => {
+  test("all checks pass — exits zero with each runner check invoked once", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
+    const stub = happyRunnerStub();
+    let viewerCalls = 0;
+    let inReviewCalls = 0;
 
     const code = await doctor({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
-      runner: happyRunner(),
-      linearViewerCheck: () => Promise.resolve(),
-      linearInReviewStateCheck: () => Promise.resolve(),
+      runner: buildRunner(stub),
+      linearViewerCheck: () => {
+        viewerCalls += 1;
+        return Promise.resolve();
+      },
+      linearInReviewStateCheck: () => {
+        inReviewCalls += 1;
+        return Promise.resolve();
+      },
     });
 
     expect(code).toBe(0);
-    const out = sinks.stdout.join("");
-    expect(out).toContain("gh auth");
-    expect(out).toContain(".tide/.env");
-    expect(out).toContain(".tide/config.ts");
-    expect(out).toContain("docker daemon");
-    expect(out).toContain("Linear API");
-    expect(out).toContain('Linear "In Review" state');
-    expect(out).toContain("gh repo identity");
-    expect(out).toContain("tide version");
-    expect(out).toContain("all checks passed");
+    expect(viewerCalls).toBe(1);
+    expect(inReviewCalls).toBe(1);
+    const cmds = stub.calls.map((c) => [c.cmd, ...c.args].join(" "));
+    expect(cmds).toContain("gh auth status");
+    expect(cmds).toContain("docker info");
+    expect(cmds).toContain("gh repo view --json owner,name");
   });
 
   test("all checks pass with CLAUDE_CODE_OAUTH_TOKEN in place of ANTHROPIC_API_KEY", async () => {
@@ -135,58 +109,48 @@ describe("tide doctor", () => {
       "LINEAR_API_KEY=lk\nCLAUDE_CODE_OAUTH_TOKEN=tok\n"
     );
     writeValidConfig();
-    const sinks = makeSinks();
 
     const code = await doctor({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
-      runner: happyRunner(),
+      runner: buildRunner(happyRunnerStub()),
       linearViewerCheck: () => Promise.resolve(),
       linearInReviewStateCheck: () => Promise.resolve(),
     });
 
     expect(code).toBe(0);
-    expect(sinks.stdout.join("")).toContain("all checks passed");
   });
 
-  test("missing `In Review` state yields non-zero exit with a `tide setup` hint", async () => {
+  test("missing `In Review` state yields non-zero exit; the check is invoked", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
+    let inReviewCalls = 0;
 
     const code = await doctor({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
-      runner: happyRunner(),
+      runner: buildRunner(happyRunnerStub()),
       linearViewerCheck: () => Promise.resolve(),
-      linearInReviewStateCheck: () =>
-        Promise.reject(
+      linearInReviewStateCheck: () => {
+        inReviewCalls += 1;
+        return Promise.reject(
           new Error(
             'Linear team "ENG" has no `started`-type workflow state named "In Review". Run `tide setup` to provision it.'
           )
-        ),
+        );
+      },
     });
 
     expect(code).toBe(1);
-    const stderr = sinks.stderr.join("");
-    expect(stderr).toContain("In Review");
-    expect(stderr).toContain("tide setup");
-    expect(sinks.stdout.join("")).toContain('Linear "In Review" state');
+    expect(inReviewCalls).toBe(1);
   });
 
   test("`In Review` check receives the apiKey and teamKey from env+config", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
     const calls: { apiKey: string; teamKey: string }[] = [];
 
     await doctor({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
-      runner: happyRunner(),
+      runner: buildRunner(happyRunnerStub()),
       linearViewerCheck: () => Promise.resolve(),
       linearInReviewStateCheck: (ctx) => {
         calls.push({ apiKey: ctx.apiKey, teamKey: ctx.teamKey });
@@ -197,11 +161,10 @@ describe("tide doctor", () => {
     expect(calls).toEqual([{ apiKey: "lk", teamKey: "ENG" }]);
   });
 
-  test("gh auth failure exits non-zero with a remediation hint", async () => {
+  test("gh auth failure exits non-zero", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
-    const runner = buildRunner({
+    const stub: RunnerStub = {
       calls: [],
       responses: {
         "gh auth status": { exitCode: 1, stdout: "" },
@@ -211,78 +174,80 @@ describe("tide doctor", () => {
           stdout: JSON.stringify({ owner: { login: "m1yon" }, name: "tide" }),
         },
       },
-    });
+    };
 
     const code = await doctor({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
-      runner,
+      runner: buildRunner(stub),
       linearViewerCheck: () => Promise.resolve(),
       linearInReviewStateCheck: () => Promise.resolve(),
     });
 
     expect(code).toBe(1);
-    expect(sinks.stderr.join("")).toContain("gh auth login");
+    const cmds = stub.calls.map((c) => [c.cmd, ...c.args].join(" "));
+    expect(cmds).toContain("gh auth status");
   });
 
-  test("missing .tide/.env yields a non-zero exit and clear hint", async () => {
+  test("missing .tide/.env yields a non-zero exit and skips Linear API check", async () => {
     writeValidConfig();
-    const sinks = makeSinks();
+    let viewerCalls = 0;
 
     const code = await doctor({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
-      runner: happyRunner(),
-      linearViewerCheck: () => Promise.resolve(),
+      runner: buildRunner(happyRunnerStub()),
+      linearViewerCheck: () => {
+        viewerCalls += 1;
+        return Promise.resolve();
+      },
       linearInReviewStateCheck: () => Promise.resolve(),
     });
 
     expect(code).toBe(1);
-    expect(sinks.stderr.join("")).toContain("env file not found");
+    // Linear API check is gated on .env loading; missing .env should skip it.
+    expect(viewerCalls).toBe(0);
   });
 
-  test("missing required env key yields a non-zero exit and names the key", async () => {
+  test("missing required env key yields non-zero exit and skips Linear API check", async () => {
     writeFileSync(join(tideDir, ".env"), "ANTHROPIC_API_KEY=ak\n");
     writeValidConfig();
-    const sinks = makeSinks();
+    let viewerCalls = 0;
 
     const code = await doctor({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
-      runner: happyRunner(),
-      linearViewerCheck: () => Promise.resolve(),
+      runner: buildRunner(happyRunnerStub()),
+      linearViewerCheck: () => {
+        viewerCalls += 1;
+        return Promise.resolve();
+      },
       linearInReviewStateCheck: () => Promise.resolve(),
     });
 
     expect(code).toBe(1);
-    expect(sinks.stderr.join("")).toContain("LINEAR_API_KEY");
+    expect(viewerCalls).toBe(0);
   });
 
-  test("missing .tide/config.ts yields a non-zero exit", async () => {
+  test("missing .tide/config.ts yields a non-zero exit and skips In Review check", async () => {
     writeValidEnv();
-    const sinks = makeSinks();
+    let inReviewCalls = 0;
 
     const code = await doctor({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
-      runner: happyRunner(),
+      runner: buildRunner(happyRunnerStub()),
       linearViewerCheck: () => Promise.resolve(),
-      linearInReviewStateCheck: () => Promise.resolve(),
+      linearInReviewStateCheck: () => {
+        inReviewCalls += 1;
+        return Promise.resolve();
+      },
     });
 
     expect(code).toBe(1);
-    expect(sinks.stderr.join("")).toContain("config file not found");
+    expect(inReviewCalls).toBe(0);
   });
 
-  test("docker daemon unreachable yields a non-zero exit and clear hint", async () => {
+  test("docker daemon unreachable yields a non-zero exit", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
-    const runner = buildRunner({
+    const stub: RunnerStub = {
       calls: [],
       responses: {
         "gh auth status": { exitCode: 0, stdout: "" },
@@ -292,44 +257,43 @@ describe("tide doctor", () => {
           stdout: JSON.stringify({ owner: { login: "m1yon" }, name: "tide" }),
         },
       },
-    });
+    };
 
     const code = await doctor({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
-      runner,
+      runner: buildRunner(stub),
       linearViewerCheck: () => Promise.resolve(),
       linearInReviewStateCheck: () => Promise.resolve(),
     });
 
     expect(code).toBe(1);
-    expect(sinks.stderr.join("")).toContain("Docker daemon");
+    const cmds = stub.calls.map((c) => [c.cmd, ...c.args].join(" "));
+    expect(cmds).toContain("docker info");
   });
 
-  test("Linear API failure yields a non-zero exit with the underlying message", async () => {
+  test("Linear API failure yields a non-zero exit", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
+    let viewerCalls = 0;
 
     const code = await doctor({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
-      runner: happyRunner(),
-      linearViewerCheck: () => Promise.reject(new Error("invalid api key")),
+      runner: buildRunner(happyRunnerStub()),
+      linearViewerCheck: () => {
+        viewerCalls += 1;
+        return Promise.reject(new Error("invalid api key"));
+      },
       linearInReviewStateCheck: () => Promise.resolve(),
     });
 
     expect(code).toBe(1);
-    expect(sinks.stderr.join("")).toContain("invalid api key");
+    expect(viewerCalls).toBe(1);
   });
 
   test("gh repo identity failure yields a non-zero exit", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
-    const runner = buildRunner({
+    const stub: RunnerStub = {
       calls: [],
       responses: {
         "gh auth status": { exitCode: 0, stdout: "" },
@@ -340,34 +304,30 @@ describe("tide doctor", () => {
           stderr: "no remote",
         },
       },
-    });
+    };
 
     const code = await doctor({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
-      runner,
+      runner: buildRunner(stub),
       linearViewerCheck: () => Promise.resolve(),
       linearInReviewStateCheck: () => Promise.resolve(),
     });
 
     expect(code).toBe(1);
-    expect(sinks.stderr.join("")).toContain("gh repo view");
+    const cmds = stub.calls.map((c) => [c.cmd, ...c.args].join(" "));
+    expect(cmds).toContain("gh repo view --json owner,name");
   });
 
-  test("invoked outside any git repo errors clearly without a stack trace", async () => {
+  test("invoked outside any git repo exits non-zero", async () => {
     const lonely = join(workDir, "lonely");
     mkdirSync(lonely, { recursive: true });
-    const sinks = makeSinks();
 
     const originalCwd = process.cwd();
     let code: number;
     try {
       process.chdir(lonely);
       code = await doctor({
-        stdout: sinks.pushStdout,
-        stderr: sinks.pushStderr,
-        runner: happyRunner(),
+        runner: buildRunner(happyRunnerStub()),
         linearViewerCheck: () => Promise.resolve(),
         linearInReviewStateCheck: () => Promise.resolve(),
       });
@@ -376,6 +336,5 @@ describe("tide doctor", () => {
     }
 
     expect(code).toBe(1);
-    expect(sinks.stderr.join("")).toContain("not inside a git repository");
   });
 });

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { intro, log, outro } from "@clack/prompts";
 import { discoverRepoRoot } from "../repo-discovery/index.ts";
 import { loadConfig } from "../config-loader/index.ts";
 import { loadEnv } from "../env-loader/index.ts";
@@ -71,8 +72,6 @@ export type LinearInReviewStateCheck = (ctx: LinearContext) => Promise<void>;
 export interface DoctorOptions {
   /** Repo root override (defaults to repo-discovery from cwd). */
   repoRoot?: string;
-  stdout?: (chunk: string) => void;
-  stderr?: (chunk: string) => void;
   /** Process runner (used by tests to stub gh + docker). */
   runner?: Runner;
   /** Linear API key check (used by tests to stub the Linear SDK). */
@@ -91,29 +90,27 @@ interface Step {
   run: () => Promise<CheckResult> | CheckResult;
 }
 
-const STATUS_OK = "ok";
-const STATUS_FAIL = "FAIL";
-
 /**
  * Runs the full preflight matrix in fixed order, printing each step's status.
  * Exits zero when every step passes; non-zero otherwise. The first failure
  * is annotated with a remediation hint.
  */
 export async function doctor(options: DoctorOptions = {}): Promise<number> {
-  const stdout = options.stdout ?? ((s: string) => process.stdout.write(s));
-  const stderr = options.stderr ?? ((s: string) => process.stderr.write(s));
   const runner = options.runner ?? defaultRunner;
   const linearViewerCheck =
     options.linearViewerCheck ?? defaultLinearViewerCheck;
   const linearInReviewStateCheck =
     options.linearInReviewStateCheck ?? defaultAssertInReviewStatePresent;
 
+  intro("tide doctor");
+
   let repoRoot: string;
   try {
     repoRoot = options.repoRoot ?? discoverRepoRoot();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    stderr(`${msg}\n`);
+    log.error(msg);
+    outro("Aborted.");
     return 1;
   }
 
@@ -275,9 +272,11 @@ export async function doctor(options: DoctorOptions = {}): Promise<number> {
     }
 
     if (result.ok) {
-      stdout(`  [${STATUS_OK}]   ${step.name}\n`);
+      log.success(step.name);
     } else {
-      stdout(`  [${STATUS_FAIL}] ${step.name}\n`);
+      log.error(
+        result.hint !== undefined ? `${step.name}: ${result.hint}` : step.name
+      );
       if (!failed && result.hint !== undefined) {
         firstFailureHint = result.hint;
       }
@@ -286,12 +285,14 @@ export async function doctor(options: DoctorOptions = {}): Promise<number> {
   }
 
   if (failed) {
-    if (firstFailureHint !== null) {
-      stderr(`\ntide doctor: ${firstFailureHint}\n`);
-    }
+    outro(
+      firstFailureHint !== null
+        ? `tide doctor: ${firstFailureHint}`
+        : "tide doctor: one or more checks failed."
+    );
     return 1;
   }
 
-  stdout(`\ntide doctor: all checks passed.\n`);
+  outro("tide doctor: all checks passed.");
   return 0;
 }

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -8,6 +8,11 @@ import {
   assertInReviewStatePresent as defaultAssertInReviewStatePresent,
   type LinearContext,
 } from "../linear/index.ts";
+import {
+  classifyBridge as defaultClassifyBridge,
+  describeBridgeForUser,
+  type BridgeState,
+} from "../sandcastle-bridge/index.ts";
 
 declare const VERSION: string | undefined;
 const version: string = typeof VERSION === "string" ? VERSION : "dev";
@@ -69,6 +74,13 @@ const defaultLinearViewerCheck: LinearViewerCheck = async (apiKey) => {
  */
 export type LinearInReviewStateCheck = (ctx: LinearContext) => Promise<void>;
 
+/**
+ * Inspects the on-disk shape of the sandcastle bridge. Pulled out as a test
+ * seam so doctor tests can assert ordering against the runner's call log
+ * without setting up filesystem fixtures for every state.
+ */
+export type ClassifyBridgeFn = (repoRoot: string) => BridgeState;
+
 export interface DoctorOptions {
   /** Repo root override (defaults to repo-discovery from cwd). */
   repoRoot?: string;
@@ -78,6 +90,8 @@ export interface DoctorOptions {
   linearViewerCheck?: LinearViewerCheck;
   /** Linear `In Review` state check (used by tests to stub the SDK). */
   linearInReviewStateCheck?: LinearInReviewStateCheck;
+  /** Sandcastle bridge classification (used by tests to stub on-disk shape). */
+  classifyBridge?: ClassifyBridgeFn;
 }
 
 interface CheckResult {
@@ -101,6 +115,7 @@ export async function doctor(options: DoctorOptions = {}): Promise<number> {
     options.linearViewerCheck ?? defaultLinearViewerCheck;
   const linearInReviewStateCheck =
     options.linearInReviewStateCheck ?? defaultAssertInReviewStatePresent;
+  const classifyBridgeFn = options.classifyBridge ?? defaultClassifyBridge;
 
   intro("tide doctor");
 
@@ -120,6 +135,23 @@ export async function doctor(options: DoctorOptions = {}): Promise<number> {
   let teamKeyCache: string | null = null;
 
   const steps: Step[] = [
+    {
+      // Check #1 by design: zero preconditions (no env, no config, no Linear,
+      // no GitHub) and a broken bridge invalidates the path assumptions every
+      // later check makes about `.sandcastle/`. Detect-only — repair lives in
+      // `tide setup`. See ADR-0011.
+      name: "sandcastle bridge",
+      run: () => {
+        const state = classifyBridgeFn(repoRoot);
+        if (state.kind === "intact" || state.kind === "missing") {
+          return { ok: true };
+        }
+        return {
+          ok: false,
+          hint: `${describeBridgeForUser(state)} Run \`tide setup\` to repair.`,
+        };
+      },
+    },
     {
       name: "gh auth",
       run: async () => {

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -20,8 +20,6 @@
 // the sole PR↔root link — Linear's GitHub integration auto-transitions
 // the root on merge (ADR-0006).
 
-import { existsSync, lstatSync, mkdirSync, symlinkSync } from "node:fs";
-import path from "node:path";
 import {
   intro,
   outro,
@@ -31,6 +29,7 @@ import {
   isCancel,
   cancel,
 } from "@clack/prompts";
+import { createBridgeIfMissing } from "../sandcastle-bridge/index.ts";
 import { build as defaultBuild, type BuildOptions } from "./build.ts";
 import { loadConfig, type TideConfig } from "../config-loader/index.ts";
 import { loadEnv } from "../env-loader/index.ts";
@@ -603,35 +602,6 @@ export async function runQueueAfterPick(
   return tail.exitCode;
 }
 
-/**
- * Ensure that Sandcastle's hardcoded `.sandcastle/` directory points at the
- * tide-conventional `.tide/`. Sandcastle writes worktrees and logs under
- * `<repoRoot>/.sandcastle/{worktrees,logs}/`; we want them under `.tide/`
- * per the PRD. A symlink is the cleanest available mechanism — Sandcastle
- * already calls `realPath` to handle the symlinked case.
- */
-function ensureSandcastleSymlink(repoRoot: string): void {
-  const tideDir = path.join(repoRoot, ".tide");
-  if (!existsSync(tideDir)) {
-    // The .tide directory should always exist by the time `tide run` is
-    // invoked (loadConfig would have errored otherwise), but be defensive.
-    mkdirSync(tideDir, { recursive: true });
-  }
-
-  const sandcastleDir = path.join(repoRoot, ".sandcastle");
-  if (existsSync(sandcastleDir)) {
-    // If it exists, it's either our own symlink (good) or something the user
-    // put there. If it's a symlink we trust it; if it's a real directory we
-    // leave it alone (don't clobber user state).
-    const stat = lstatSync(sandcastleDir);
-    if (stat.isSymbolicLink()) return;
-    return;
-  }
-
-  // Relative symlink so the repo can be moved without breaking the link.
-  symlinkSync(".tide", sandcastleDir, "dir");
-}
-
 export async function tideRun(options: RunOptions = {}): Promise<number> {
   const stdout = options.stdout ?? ((s: string) => process.stdout.write(s));
   const stderr = options.stderr ?? ((s: string) => process.stderr.write(s));
@@ -745,8 +715,16 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
 
   // Sandcastle writes worktrees/logs under `.sandcastle/`. Tide's convention
   // is `.tide/`. Bridge with a symlink so the SDK paths land in the right
-  // place. (See PRD: "Sandcastle worktrees and logs land at .tide/...".)
-  ensureSandcastleSymlink(repoRoot);
+  // place. Residual safety net — only creates on `missing`, throws fast on a
+  // broken bridge with a hint to run `tide setup`. The full classify + repair
+  // lifecycle lives in `tide setup`.
+  try {
+    createBridgeIfMissing(repoRoot);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    stderr(`${msg}\n`);
+    return 1;
+  }
 
   // Ensure the sandbox image is up to date before any clack UI is started —
   // streamed docker output otherwise interferes with clack rendering.

--- a/src/cli/setup.test.ts
+++ b/src/cli/setup.test.ts
@@ -15,29 +15,6 @@ import {
   type SetupLabelResult,
 } from "../linear/index.ts";
 
-interface Sinks {
-  stdout: string[];
-  stderr: string[];
-  pushStdout: (s: string) => void;
-  pushStderr: (s: string) => void;
-}
-
-function makeSinks(): Sinks {
-  const sinks: Sinks = {
-    stdout: [],
-    stderr: [],
-    pushStdout: () => undefined,
-    pushStderr: () => undefined,
-  };
-  sinks.pushStdout = (s: string) => {
-    sinks.stdout.push(s);
-  };
-  sinks.pushStderr = (s: string) => {
-    sinks.stderr.push(s);
-  };
-  return sinks;
-}
-
 interface SetupLabelsCapture {
   ctx: LinearContext | null;
   callCount: number;
@@ -110,14 +87,11 @@ describe("tide setup", () => {
   test("on a fresh team, creates all three labels + the In Review state and exits zero", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
     const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
     const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
 
     const code = await setup({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
       setupLabels: buildSetupLabels(allLabelsCreated(), labelCapture),
       provisionInReviewState: buildProvisionState(
         { name: IN_REVIEW_STATE_NAME, created: true },
@@ -132,26 +106,16 @@ describe("tide setup", () => {
     expect(labelCapture.ctx?.teamKey).toBe("ENG");
     expect(stateCapture.ctx?.apiKey).toBe("lk");
     expect(stateCapture.ctx?.teamKey).toBe("ENG");
-
-    const out = sinks.stdout.join("");
-    expect(out).toContain("ENG");
-    expect(out).toContain("created");
-    for (const name of SETUP_LABEL_NAMES) expect(out).toContain(name);
-    expect(out).toContain(IN_REVIEW_STATE_NAME);
-    expect(out).toContain("created 4 resource(s)");
   });
 
-  test("on a fully provisioned team, reports nothing-to-do and exits zero", async () => {
+  test("on a fully provisioned team, exits zero with both stubs called once", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
     const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
     const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
 
     const code = await setup({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
       setupLabels: buildSetupLabels(allLabelsPresent(), labelCapture),
       provisionInReviewState: buildProvisionState(
         { name: IN_REVIEW_STATE_NAME, created: false },
@@ -160,16 +124,13 @@ describe("tide setup", () => {
     });
 
     expect(code).toBe(0);
-    const out = sinks.stdout.join("");
-    expect(out).toContain("already present");
-    expect(out).toContain(IN_REVIEW_STATE_NAME);
-    expect(out).toContain("nothing to do");
+    expect(labelCapture.callCount).toBe(1);
+    expect(stateCapture.callCount).toBe(1);
   });
 
-  test("partial pre-existing: reports both created and already-present sections in one unified summary", async () => {
+  test("partial pre-existing: both stubs called and exits zero", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
     const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
     const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
     const results: SetupLabelResult[] = [
@@ -180,8 +141,6 @@ describe("tide setup", () => {
 
     const code = await setup({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
       setupLabels: buildSetupLabels(results, labelCapture),
       provisionInReviewState: buildProvisionState(
         { name: IN_REVIEW_STATE_NAME, created: true },
@@ -190,27 +149,18 @@ describe("tide setup", () => {
     });
 
     expect(code).toBe(0);
-    const out = sinks.stdout.join("");
-    expect(out).toContain("created:");
-    expect(out).toContain("already present:");
-    expect(out).toContain("ready-for-agent");
-    expect(out).toContain("ready-for-human");
-    expect(out).toContain("prd");
-    // Single unified summary — labels and states reported together.
-    expect(out).toContain(IN_REVIEW_STATE_NAME);
+    expect(labelCapture.callCount).toBe(1);
+    expect(stateCapture.callCount).toBe(1);
   });
 
   test("provisions the In Review state via provisionInReviewState (single call, ctx forwarded)", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
     const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
     const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
 
     const code = await setup({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
       setupLabels: buildSetupLabels(allLabelsCreated(), labelCapture),
       provisionInReviewState: buildProvisionState(
         { name: IN_REVIEW_STATE_NAME, created: true },
@@ -224,17 +174,14 @@ describe("tide setup", () => {
     expect(stateCapture.ctx?.teamKey).toBe("ENG");
   });
 
-  test("In Review already present is reported as such in the unified summary", async () => {
+  test("In Review already present: state stub returns created:false and exits zero", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
     const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
     const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
 
     const code = await setup({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
       setupLabels: buildSetupLabels(allLabelsCreated(), labelCapture),
       provisionInReviewState: buildProvisionState(
         { name: IN_REVIEW_STATE_NAME, created: false },
@@ -243,21 +190,16 @@ describe("tide setup", () => {
     });
 
     expect(code).toBe(0);
-    const out = sinks.stdout.join("");
-    expect(out).toContain("already present");
-    expect(out).toContain(IN_REVIEW_STATE_NAME);
+    expect(stateCapture.callCount).toBe(1);
   });
 
-  test("missing .tide/.env yields non-zero exit and a clear hint", async () => {
+  test("missing .tide/.env yields non-zero exit and skips both Linear stubs", async () => {
     writeValidConfig();
-    const sinks = makeSinks();
     const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
     const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
 
     const code = await setup({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
       setupLabels: buildSetupLabels([], labelCapture),
       provisionInReviewState: buildProvisionState(
         { name: IN_REVIEW_STATE_NAME, created: false },
@@ -268,20 +210,16 @@ describe("tide setup", () => {
     expect(code).toBe(1);
     expect(labelCapture.callCount).toBe(0);
     expect(stateCapture.callCount).toBe(0);
-    expect(sinks.stderr.join("")).toContain("env file not found");
   });
 
-  test("missing LINEAR_API_KEY yields non-zero exit and names the key", async () => {
+  test("missing LINEAR_API_KEY yields non-zero exit and skips both Linear stubs", async () => {
     writeFileSync(join(tideDir, ".env"), "ANTHROPIC_API_KEY=ak\n");
     writeValidConfig();
-    const sinks = makeSinks();
     const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
     const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
 
     const code = await setup({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
       setupLabels: buildSetupLabels([], labelCapture),
       provisionInReviewState: buildProvisionState(
         { name: IN_REVIEW_STATE_NAME, created: false },
@@ -292,19 +230,15 @@ describe("tide setup", () => {
     expect(code).toBe(1);
     expect(labelCapture.callCount).toBe(0);
     expect(stateCapture.callCount).toBe(0);
-    expect(sinks.stderr.join("")).toContain("LINEAR_API_KEY");
   });
 
-  test("missing .tide/config.ts yields non-zero exit", async () => {
+  test("missing .tide/config.ts yields non-zero exit and skips both Linear stubs", async () => {
     writeValidEnv();
-    const sinks = makeSinks();
     const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
     const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
 
     const code = await setup({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
       setupLabels: buildSetupLabels([], labelCapture),
       provisionInReviewState: buildProvisionState(
         { name: IN_REVIEW_STATE_NAME, created: false },
@@ -315,21 +249,17 @@ describe("tide setup", () => {
     expect(code).toBe(1);
     expect(labelCapture.callCount).toBe(0);
     expect(stateCapture.callCount).toBe(0);
-    expect(sinks.stderr.join("")).toContain("config file not found");
   });
 
-  test("Linear setupLabels failure surfaces a clear error and non-zero exit", async () => {
+  test("Linear setupLabels failure yields non-zero exit; state step still runs", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
     const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
     const setupLabelsFn: SetupLabelsFn = () =>
       Promise.reject(new Error("invalid api key"));
 
     const code = await setup({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
       setupLabels: setupLabelsFn,
       provisionInReviewState: buildProvisionState(
         { name: IN_REVIEW_STATE_NAME, created: false },
@@ -338,48 +268,37 @@ describe("tide setup", () => {
     });
 
     expect(code).toBe(1);
-    expect(sinks.stderr.join("")).toContain("invalid api key");
+    expect(stateCapture.callCount).toBe(1);
   });
 
-  test("provisionInReviewState failure surfaces independently and yields non-zero exit", async () => {
+  test("provisionInReviewState failure does not skip setupLabels; both ran, exits non-zero", async () => {
     // Per-resource failures are reported independently — a state failure
-    // does not skip the label step, and the user sees both outcomes in one
-    // unified summary.
+    // does not skip the label step.
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
     const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
     const provisionFn: ProvisionInReviewStateFn = () =>
       Promise.reject(new Error("In Progress flank missing"));
 
     const code = await setup({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
       setupLabels: buildSetupLabels(allLabelsCreated(), labelCapture),
       provisionInReviewState: provisionFn,
     });
 
     expect(code).toBe(1);
     expect(labelCapture.callCount).toBe(1);
-    expect(sinks.stderr.join("")).toContain("In Progress flank missing");
-    // Labels still reported in the summary even though state failed.
-    const out = sinks.stdout.join("");
-    for (const name of SETUP_LABEL_NAMES) expect(out).toContain(name);
   });
 
-  test("setupLabels failure does not skip provisionInReviewState; both outcomes surface", async () => {
+  test("setupLabels failure does not skip provisionInReviewState; both stubs ran", async () => {
     writeValidEnv();
     writeValidConfig();
-    const sinks = makeSinks();
     const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
     const setupLabelsFn: SetupLabelsFn = () =>
       Promise.reject(new Error("label create failed"));
 
     const code = await setup({
       repoRoot,
-      stdout: sinks.pushStdout,
-      stderr: sinks.pushStderr,
       setupLabels: setupLabelsFn,
       provisionInReviewState: buildProvisionState(
         { name: IN_REVIEW_STATE_NAME, created: true },
@@ -388,17 +307,12 @@ describe("tide setup", () => {
     });
 
     expect(code).toBe(1);
-    // State step still ran independently.
     expect(stateCapture.callCount).toBe(1);
-    expect(sinks.stderr.join("")).toContain("label create failed");
-    // The created In Review state is still reflected in the summary.
-    expect(sinks.stdout.join("")).toContain(IN_REVIEW_STATE_NAME);
   });
 
-  test("invoked outside any git repo errors clearly without a stack trace", async () => {
+  test("invoked outside any git repo exits non-zero and skips both Linear stubs", async () => {
     const lonely = join(workDir, "lonely");
     mkdirSync(lonely, { recursive: true });
-    const sinks = makeSinks();
     const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
     const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
 
@@ -407,8 +321,6 @@ describe("tide setup", () => {
     try {
       process.chdir(lonely);
       code = await setup({
-        stdout: sinks.pushStdout,
-        stderr: sinks.pushStderr,
         setupLabels: buildSetupLabels([], labelCapture),
         provisionInReviewState: buildProvisionState(
           { name: IN_REVIEW_STATE_NAME, created: false },
@@ -422,6 +334,5 @@ describe("tide setup", () => {
     expect(code).toBe(1);
     expect(labelCapture.callCount).toBe(0);
     expect(stateCapture.callCount).toBe(0);
-    expect(sinks.stderr.join("")).toContain("not inside a git repository");
   });
 });

--- a/src/cli/setup.test.ts
+++ b/src/cli/setup.test.ts
@@ -1,9 +1,18 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   setup,
+  type ConfirmBridgeRepairFn,
   type ProvisionInReviewStateFn,
   type SetupLabelsFn,
 } from "./setup.ts";
@@ -14,6 +23,7 @@ import {
   type ProvisionInReviewStateResult,
   type SetupLabelResult,
 } from "../linear/index.ts";
+import { classifyBridge } from "../sandcastle-bridge/index.ts";
 
 interface SetupLabelsCapture {
   ctx: LinearContext | null;
@@ -334,5 +344,167 @@ describe("tide setup", () => {
     expect(code).toBe(1);
     expect(labelCapture.callCount).toBe(0);
     expect(stateCapture.callCount).toBe(0);
+  });
+
+  describe("sandcastle bridge step", () => {
+    test("missing bridge: silently auto-creates the symlink (no prompt)", async () => {
+      writeValidEnv();
+      writeValidConfig();
+      const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
+      const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
+      let confirmCalls = 0;
+      const confirmFn: ConfirmBridgeRepairFn = () => {
+        confirmCalls += 1;
+        return Promise.resolve(false);
+      };
+
+      const code = await setup({
+        repoRoot,
+        setupLabels: buildSetupLabels(allLabelsCreated(), labelCapture),
+        provisionInReviewState: buildProvisionState(
+          { name: IN_REVIEW_STATE_NAME, created: true },
+          stateCapture
+        ),
+        confirmBridgeRepair: confirmFn,
+      });
+
+      expect(code).toBe(0);
+      expect(confirmCalls).toBe(0);
+      expect(classifyBridge(repoRoot)).toEqual({ kind: "intact" });
+    });
+
+    test("intact bridge: silent no-op (no prompt, no churn)", async () => {
+      writeValidEnv();
+      writeValidConfig();
+      symlinkSync(".tide", join(repoRoot, ".sandcastle"), "dir");
+      const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
+      const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
+      let confirmCalls = 0;
+      const confirmFn: ConfirmBridgeRepairFn = () => {
+        confirmCalls += 1;
+        return Promise.resolve(false);
+      };
+
+      const code = await setup({
+        repoRoot,
+        setupLabels: buildSetupLabels(allLabelsCreated(), labelCapture),
+        provisionInReviewState: buildProvisionState(
+          { name: IN_REVIEW_STATE_NAME, created: true },
+          stateCapture
+        ),
+        confirmBridgeRepair: confirmFn,
+      });
+
+      expect(code).toBe(0);
+      expect(confirmCalls).toBe(0);
+      expect(classifyBridge(repoRoot)).toEqual({ kind: "intact" });
+    });
+
+    test("broken bridge + confirm true: repairs the bridge and exits zero", async () => {
+      writeValidEnv();
+      writeValidConfig();
+      mkdirSync(join(repoRoot, ".sandcastle"));
+      mkdirSync(join(repoRoot, ".sandcastle", "worktrees"));
+      const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
+      const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
+
+      const code = await setup({
+        repoRoot,
+        setupLabels: buildSetupLabels(allLabelsCreated(), labelCapture),
+        provisionInReviewState: buildProvisionState(
+          { name: IN_REVIEW_STATE_NAME, created: true },
+          stateCapture
+        ),
+        confirmBridgeRepair: () => Promise.resolve(true),
+      });
+
+      expect(code).toBe(0);
+      expect(classifyBridge(repoRoot)).toEqual({ kind: "intact" });
+      const stat = lstatSync(join(repoRoot, ".sandcastle"));
+      expect(stat.isSymbolicLink()).toBe(true);
+      expect(readlinkSync(join(repoRoot, ".sandcastle"))).toBe(".tide");
+      expect(labelCapture.callCount).toBe(1);
+      expect(stateCapture.callCount).toBe(1);
+    });
+
+    test("broken bridge + confirm false: exits non-zero, bridge untouched, Linear half not invoked", async () => {
+      writeValidEnv();
+      writeValidConfig();
+      writeFileSync(join(repoRoot, ".sandcastle"), "junk\n");
+      const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
+      const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
+
+      const code = await setup({
+        repoRoot,
+        setupLabels: buildSetupLabels(allLabelsCreated(), labelCapture),
+        provisionInReviewState: buildProvisionState(
+          { name: IN_REVIEW_STATE_NAME, created: true },
+          stateCapture
+        ),
+        confirmBridgeRepair: () => Promise.resolve(false),
+      });
+
+      expect(code).toBe(1);
+      expect(classifyBridge(repoRoot)).toEqual({ kind: "regular-file" });
+      expect(labelCapture.callCount).toBe(0);
+      expect(stateCapture.callCount).toBe(0);
+    });
+
+    test("bridge step runs before env/config: missing LINEAR_API_KEY does not skip the bridge", async () => {
+      // .env present but LINEAR_API_KEY missing. The bridge should still be
+      // repaired so a fresh-clone partial setup leaves a healthy bridge even
+      // when the Linear half can't run.
+      writeFileSync(join(tideDir, ".env"), "ANTHROPIC_API_KEY=ak\n");
+      writeValidConfig();
+      mkdirSync(join(repoRoot, ".sandcastle"));
+      mkdirSync(join(repoRoot, ".sandcastle", "worktrees"));
+      const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
+      const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
+
+      const code = await setup({
+        repoRoot,
+        setupLabels: buildSetupLabels(allLabelsCreated(), labelCapture),
+        provisionInReviewState: buildProvisionState(
+          { name: IN_REVIEW_STATE_NAME, created: true },
+          stateCapture
+        ),
+        confirmBridgeRepair: () => Promise.resolve(true),
+      });
+
+      expect(code).toBe(1);
+      expect(classifyBridge(repoRoot)).toEqual({ kind: "intact" });
+      expect(labelCapture.callCount).toBe(0);
+      expect(stateCapture.callCount).toBe(0);
+    });
+
+    test("bridge step runs before env/config: missing .tide/.env does not skip the bridge", async () => {
+      // Neither .env nor a broken bridge — but a broken bridge with no env at
+      // all means the bridge step must still classify + prompt + repair before
+      // env loading errors out.
+      writeValidConfig();
+      mkdirSync(join(repoRoot, ".sandcastle"));
+      const labelCapture: SetupLabelsCapture = { ctx: null, callCount: 0 };
+      const stateCapture: ProvisionStateCapture = { ctx: null, callCount: 0 };
+      let confirmCalls = 0;
+
+      const code = await setup({
+        repoRoot,
+        setupLabels: buildSetupLabels(allLabelsCreated(), labelCapture),
+        provisionInReviewState: buildProvisionState(
+          { name: IN_REVIEW_STATE_NAME, created: true },
+          stateCapture
+        ),
+        confirmBridgeRepair: () => {
+          confirmCalls += 1;
+          return Promise.resolve(true);
+        },
+      });
+
+      expect(code).toBe(1);
+      expect(confirmCalls).toBe(1);
+      expect(classifyBridge(repoRoot)).toEqual({ kind: "intact" });
+      expect(labelCapture.callCount).toBe(0);
+      expect(stateCapture.callCount).toBe(0);
+    });
   });
 });

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,3 +1,4 @@
+import { intro, log, outro, spinner } from "@clack/prompts";
 import { discoverRepoRoot } from "../repo-discovery/index.ts";
 import { loadConfig } from "../config-loader/index.ts";
 import { loadEnv } from "../env-loader/index.ts";
@@ -26,8 +27,6 @@ export type ProvisionInReviewStateFn = (
 export interface SetupOptions {
   /** Repo root override (defaults to repo-discovery from cwd). */
   repoRoot?: string;
-  stdout?: (chunk: string) => void;
-  stderr?: (chunk: string) => void;
   /** Linear `setupLabels` injection (used by tests to stub the SDK). */
   setupLabels?: SetupLabelsFn;
   /** Linear `provisionInReviewState` injection (used by tests). */
@@ -48,18 +47,19 @@ export interface SetupOptions {
  * always tells the user what is and is not present on the team.
  */
 export async function setup(options: SetupOptions = {}): Promise<number> {
-  const stdout = options.stdout ?? ((s: string) => process.stdout.write(s));
-  const stderr = options.stderr ?? ((s: string) => process.stderr.write(s));
   const setupLabelsFn = options.setupLabels ?? defaultSetupLabels;
   const provisionInReviewStateFn =
     options.provisionInReviewState ?? defaultProvisionInReviewState;
+
+  intro("tide setup");
 
   let repoRoot: string;
   try {
     repoRoot = options.repoRoot ?? discoverRepoRoot();
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    stderr(`${msg}\n`);
+    log.error(msg);
+    outro("Aborted.");
     return 1;
   }
 
@@ -68,13 +68,15 @@ export async function setup(options: SetupOptions = {}): Promise<number> {
     envMap = loadEnv({ repoRoot });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    stderr(`${msg}\n`);
+    log.error(msg);
+    outro("Aborted.");
     return 1;
   }
 
   const apiKey = envMap.LINEAR_API_KEY;
   if (typeof apiKey !== "string" || apiKey === "") {
-    stderr(`tide: LINEAR_API_KEY is empty in .tide/.env\n`);
+    log.error("LINEAR_API_KEY is empty in .tide/.env");
+    outro("Aborted.");
     return 1;
   }
 
@@ -84,84 +86,91 @@ export async function setup(options: SetupOptions = {}): Promise<number> {
     teamKey = config.linear.team;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
-    stderr(`${msg}\n`);
+    log.error(msg);
+    outro("Aborted.");
     return 1;
   }
 
   const ctx: LinearContext = { apiKey, teamKey };
 
+  log.info(`Linear team "${teamKey}"`);
+
   // Run the two provisioning steps independently so a failure in one is
   // surfaced without skipping the other. The user gets a single unified
   // report and a non-zero exit if anything failed.
+  const labelSpin = spinner();
+  labelSpin.start("Provisioning Linear labels");
   let labelResults: SetupLabelResult[] | undefined;
   let labelError: string | undefined;
   try {
     labelResults = await setupLabelsFn(ctx);
+    labelSpin.stop("Linear labels checked");
   } catch (err) {
     labelError = err instanceof Error ? err.message : String(err);
+    labelSpin.stop("Linear label provisioning failed");
   }
 
+  const stateSpin = spinner();
+  stateSpin.start('Provisioning "In Review" workflow state');
   let stateResult: ProvisionInReviewStateResult | undefined;
   let stateError: string | undefined;
   try {
     stateResult = await provisionInReviewStateFn(ctx);
+    stateSpin.stop('"In Review" workflow state checked');
   } catch (err) {
     stateError = err instanceof Error ? err.message : String(err);
+    stateSpin.stop('"In Review" workflow state provisioning failed');
   }
-
-  stdout(`tide setup: Linear team "${teamKey}"\n`);
 
   interface SummaryRow {
     kind: "label" | "state";
     name: string;
-    created: boolean;
   }
   const created: SummaryRow[] = [];
   const existing: SummaryRow[] = [];
   if (labelResults !== undefined) {
     for (const r of labelResults) {
-      (r.created ? created : existing).push({
-        kind: "label",
-        name: r.name,
-        created: r.created,
-      });
+      (r.created ? created : existing).push({ kind: "label", name: r.name });
     }
   }
   if (stateResult !== undefined) {
     (stateResult.created ? created : existing).push({
       kind: "state",
       name: stateResult.name,
-      created: stateResult.created,
     });
   }
 
   if (created.length > 0) {
-    stdout(`  created:\n`);
-    for (const r of created) {
-      stdout(`    - ${r.name} (${r.kind})\n`);
-    }
+    log.success(
+      ["Created:", ...created.map((r) => `  - ${r.name} (${r.kind})`)].join(
+        "\n"
+      )
+    );
   }
   if (existing.length > 0) {
-    stdout(`  already present:\n`);
-    for (const r of existing) {
-      stdout(`    - ${r.name} (${r.kind})\n`);
-    }
+    log.message(
+      [
+        "Already present:",
+        ...existing.map((r) => `  - ${r.name} (${r.kind})`),
+      ].join("\n")
+    );
   }
 
   if (labelError !== undefined) {
-    stderr(`tide setup: label provisioning failed: ${labelError}\n`);
+    log.error(`label provisioning failed: ${labelError}`);
   }
   if (stateError !== undefined) {
-    stderr(`tide setup: workflow-state provisioning failed: ${stateError}\n`);
+    log.error(`workflow-state provisioning failed: ${stateError}`);
   }
   if (labelError !== undefined || stateError !== undefined) {
+    outro("Setup completed with errors.");
     return 1;
   }
 
   if (created.length === 0) {
-    stdout(`tide setup: nothing to do — all resources already present.\n`);
+    outro("Nothing to do — all resources already present.");
   } else {
-    stdout(`tide setup: created ${String(created.length)} resource(s).\n`);
+    outro(`Created ${String(created.length)} resource(s).`);
   }
   return 0;
 }

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -1,4 +1,4 @@
-import { intro, log, outro, spinner } from "@clack/prompts";
+import { confirm, intro, isCancel, log, outro, spinner } from "@clack/prompts";
 import { discoverRepoRoot } from "../repo-discovery/index.ts";
 import { loadConfig } from "../config-loader/index.ts";
 import { loadEnv } from "../env-loader/index.ts";
@@ -9,6 +9,12 @@ import {
   type ProvisionInReviewStateResult,
   type SetupLabelResult,
 } from "../linear/index.ts";
+import {
+  classifyBridge,
+  createBridgeIfMissing,
+  describeBridgeForUser,
+  repairBridge,
+} from "../sandcastle-bridge/index.ts";
 
 /**
  * Test seam — defaults to the real `linear.setupLabels`. Tests stub this to
@@ -24,6 +30,15 @@ export type ProvisionInReviewStateFn = (
   ctx: LinearContext
 ) => Promise<ProvisionInReviewStateResult>;
 
+/**
+ * Test seam for the destructive bridge-repair confirm prompt. Returns true
+ * when the user has consented to the repair, false otherwise (decline,
+ * cancel, non-TTY). Tests stub this to bypass the clack TTY gate. The bridge
+ * state has already been described to the user via `log.warn` by the time
+ * this fires.
+ */
+export type ConfirmBridgeRepairFn = () => Promise<boolean>;
+
 export interface SetupOptions {
   /** Repo root override (defaults to repo-discovery from cwd). */
   repoRoot?: string;
@@ -31,6 +46,18 @@ export interface SetupOptions {
   setupLabels?: SetupLabelsFn;
   /** Linear `provisionInReviewState` injection (used by tests). */
   provisionInReviewState?: ProvisionInReviewStateFn;
+  /** Bridge-repair confirm prompt (used by tests to bypass clack). */
+  confirmBridgeRepair?: ConfirmBridgeRepairFn;
+}
+
+async function defaultConfirmBridgeRepair(): Promise<boolean> {
+  const answer = await confirm({
+    message:
+      "Repair the sandcastle bridge? This will delete the above and recreate the symlink.",
+    initialValue: false,
+  });
+  if (isCancel(answer)) return false;
+  return answer;
 }
 
 /**
@@ -50,6 +77,8 @@ export async function setup(options: SetupOptions = {}): Promise<number> {
   const setupLabelsFn = options.setupLabels ?? defaultSetupLabels;
   const provisionInReviewStateFn =
     options.provisionInReviewState ?? defaultProvisionInReviewState;
+  const confirmBridgeRepairFn =
+    options.confirmBridgeRepair ?? defaultConfirmBridgeRepair;
 
   intro("tide setup");
 
@@ -61,6 +90,39 @@ export async function setup(options: SetupOptions = {}): Promise<number> {
     log.error(msg);
     outro("Aborted.");
     return 1;
+  }
+
+  // Step 1: sandcastle bridge. Runs before env/config so a fresh-clone setup
+  // that fails on a missing LINEAR_API_KEY still leaves a healthy bridge. The
+  // intact and missing states are silent (auto-create on missing); the four
+  // broken states describe what's on disk and prompt before any destructive
+  // action. Decline / cancel exits non-zero with the bridge untouched.
+  const bridgeState = classifyBridge(repoRoot);
+  if (bridgeState.kind === "missing") {
+    try {
+      createBridgeIfMissing(repoRoot);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`Sandcastle bridge: ${msg}`);
+      outro("Aborted.");
+      return 1;
+    }
+  } else if (bridgeState.kind !== "intact") {
+    log.warn(describeBridgeForUser(bridgeState));
+    const confirmed = await confirmBridgeRepairFn();
+    if (!confirmed) {
+      outro("Sandcastle bridge repair declined. Aborted.");
+      return 1;
+    }
+    try {
+      repairBridge(repoRoot, bridgeState);
+      log.success("Sandcastle bridge repaired.");
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      log.error(`Sandcastle bridge repair failed: ${msg}`);
+      outro("Aborted.");
+      return 1;
+    }
   }
 
   let envMap: Record<string, string>;

--- a/src/sandcastle-bridge/index.test.ts
+++ b/src/sandcastle-bridge/index.test.ts
@@ -1,0 +1,255 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  classifyBridge,
+  createBridgeIfMissing,
+  describeBridgeForUser,
+  repairBridge,
+  type BridgeState,
+} from "./index.ts";
+
+describe("classifyBridge", () => {
+  let workDir: string;
+  let repoRoot: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "tide-bridge-classify-"));
+    repoRoot = join(workDir, "repo");
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(join(repoRoot, ".tide"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("missing — no .sandcastle entry at repo root", () => {
+    expect(classifyBridge(repoRoot)).toEqual({ kind: "missing" });
+  });
+
+  test("intact — symlink at .sandcastle pointing at .tide", () => {
+    symlinkSync(".tide", join(repoRoot, ".sandcastle"), "dir");
+    expect(classifyBridge(repoRoot)).toEqual({ kind: "intact" });
+  });
+
+  test("wrong-symlink-target — symlink pointing somewhere else", () => {
+    symlinkSync("some-other-dir", join(repoRoot, ".sandcastle"), "dir");
+    const state = classifyBridge(repoRoot);
+    expect(state).toEqual({
+      kind: "wrong-symlink-target",
+      target: "some-other-dir",
+    });
+  });
+
+  test("real-dir-empty — real directory with no entries", () => {
+    mkdirSync(join(repoRoot, ".sandcastle"));
+    expect(classifyBridge(repoRoot)).toEqual({ kind: "real-dir-empty" });
+  });
+
+  test("real-dir-empty — user-incident shape: empty worktrees/ and logs/ subdirs", () => {
+    mkdirSync(join(repoRoot, ".sandcastle"));
+    mkdirSync(join(repoRoot, ".sandcastle", "worktrees"));
+    mkdirSync(join(repoRoot, ".sandcastle", "logs"));
+    expect(classifyBridge(repoRoot)).toEqual({ kind: "real-dir-empty" });
+  });
+
+  test("real-dir-with-content — real directory containing files", () => {
+    mkdirSync(join(repoRoot, ".sandcastle"));
+    mkdirSync(join(repoRoot, ".sandcastle", "worktrees"));
+    writeFileSync(
+      join(repoRoot, ".sandcastle", "worktrees", "feature-branch.patch"),
+      "diff --git\n"
+    );
+    const state = classifyBridge(repoRoot);
+    expect(state.kind).toBe("real-dir-with-content");
+    if (state.kind !== "real-dir-with-content") return;
+    expect(state.entries).toContain("worktrees");
+  });
+
+  test("regular-file — plain file at .sandcastle", () => {
+    writeFileSync(join(repoRoot, ".sandcastle"), "garbage\n");
+    expect(classifyBridge(repoRoot)).toEqual({ kind: "regular-file" });
+  });
+});
+
+describe("repairBridge", () => {
+  let workDir: string;
+  let repoRoot: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "tide-bridge-repair-"));
+    repoRoot = join(workDir, "repo");
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(join(repoRoot, ".tide"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  function expectIntact(): void {
+    const stat = lstatSync(join(repoRoot, ".sandcastle"));
+    expect(stat.isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(repoRoot, ".sandcastle"))).toBe(".tide");
+  }
+
+  test("wrong-symlink-target → unlinks and re-symlinks at .tide", () => {
+    symlinkSync("nope", join(repoRoot, ".sandcastle"), "dir");
+    const state = classifyBridge(repoRoot);
+    repairBridge(repoRoot, state);
+    expectIntact();
+  });
+
+  test("real-dir-empty → rmdirs and re-symlinks at .tide", () => {
+    mkdirSync(join(repoRoot, ".sandcastle"));
+    mkdirSync(join(repoRoot, ".sandcastle", "worktrees"));
+    mkdirSync(join(repoRoot, ".sandcastle", "logs"));
+    const state = classifyBridge(repoRoot);
+    repairBridge(repoRoot, state);
+    expectIntact();
+  });
+
+  test("real-dir-with-content → rm -rfs and re-symlinks at .tide", () => {
+    mkdirSync(join(repoRoot, ".sandcastle"));
+    mkdirSync(join(repoRoot, ".sandcastle", "worktrees"));
+    writeFileSync(
+      join(repoRoot, ".sandcastle", "worktrees", "junk.patch"),
+      "x\n"
+    );
+    const state = classifyBridge(repoRoot);
+    repairBridge(repoRoot, state);
+    expectIntact();
+  });
+
+  test("regular-file → unlinks and re-symlinks at .tide", () => {
+    writeFileSync(join(repoRoot, ".sandcastle"), "junk\n");
+    const state = classifyBridge(repoRoot);
+    repairBridge(repoRoot, state);
+    expectIntact();
+  });
+
+  test("creates .tide directory if missing before symlinking", () => {
+    rmSync(join(repoRoot, ".tide"), { recursive: true });
+    writeFileSync(join(repoRoot, ".sandcastle"), "junk\n");
+    const state = classifyBridge(repoRoot);
+    repairBridge(repoRoot, state);
+    expectIntact();
+  });
+
+  test("throws on intact (caller invariant)", () => {
+    symlinkSync(".tide", join(repoRoot, ".sandcastle"), "dir");
+    const state = classifyBridge(repoRoot);
+    expect(() => {
+      repairBridge(repoRoot, state);
+    }).toThrow();
+  });
+
+  test("throws on missing (caller invariant)", () => {
+    const state: BridgeState = { kind: "missing" };
+    expect(() => {
+      repairBridge(repoRoot, state);
+    }).toThrow();
+  });
+});
+
+describe("createBridgeIfMissing", () => {
+  let workDir: string;
+  let repoRoot: string;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "tide-bridge-create-"));
+    repoRoot = join(workDir, "repo");
+    mkdirSync(repoRoot, { recursive: true });
+    mkdirSync(join(repoRoot, ".tide"), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("creates symlink when state is missing", () => {
+    createBridgeIfMissing(repoRoot);
+    const stat = lstatSync(join(repoRoot, ".sandcastle"));
+    expect(stat.isSymbolicLink()).toBe(true);
+    expect(readlinkSync(join(repoRoot, ".sandcastle"))).toBe(".tide");
+  });
+
+  test("creates .tide as well if missing", () => {
+    rmSync(join(repoRoot, ".tide"), { recursive: true });
+    createBridgeIfMissing(repoRoot);
+    const stat = lstatSync(join(repoRoot, ".sandcastle"));
+    expect(stat.isSymbolicLink()).toBe(true);
+  });
+
+  test("no-ops when state is intact", () => {
+    symlinkSync(".tide", join(repoRoot, ".sandcastle"), "dir");
+    createBridgeIfMissing(repoRoot);
+    expect(readlinkSync(join(repoRoot, ".sandcastle"))).toBe(".tide");
+  });
+
+  test("throws with `tide setup` hint when state is wrong-symlink-target", () => {
+    symlinkSync("nope", join(repoRoot, ".sandcastle"), "dir");
+    expect(() => {
+      createBridgeIfMissing(repoRoot);
+    }).toThrow(/tide setup/);
+  });
+
+  test("throws with `tide setup` hint when state is real-dir-empty", () => {
+    mkdirSync(join(repoRoot, ".sandcastle"));
+    expect(() => {
+      createBridgeIfMissing(repoRoot);
+    }).toThrow(/tide setup/);
+  });
+
+  test("throws with `tide setup` hint when state is real-dir-with-content", () => {
+    mkdirSync(join(repoRoot, ".sandcastle"));
+    writeFileSync(join(repoRoot, ".sandcastle", "junk"), "x\n");
+    expect(() => {
+      createBridgeIfMissing(repoRoot);
+    }).toThrow(/tide setup/);
+  });
+
+  test("throws with `tide setup` hint when state is regular-file", () => {
+    writeFileSync(join(repoRoot, ".sandcastle"), "junk\n");
+    expect(() => {
+      createBridgeIfMissing(repoRoot);
+    }).toThrow(/tide setup/);
+  });
+});
+
+describe("describeBridgeForUser", () => {
+  test("returns a non-empty string for every variant", () => {
+    const variants: BridgeState[] = [
+      { kind: "missing" },
+      { kind: "intact" },
+      { kind: "wrong-symlink-target", target: "/somewhere/else" },
+      { kind: "real-dir-empty" },
+      { kind: "real-dir-with-content", entries: ["worktrees", "logs"] },
+      { kind: "regular-file" },
+    ];
+    for (const v of variants) {
+      const desc = describeBridgeForUser(v);
+      expect(desc.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("real-dir-with-content description includes the entries list", () => {
+    const desc = describeBridgeForUser({
+      kind: "real-dir-with-content",
+      entries: ["worktrees", "logs", "patches"],
+    });
+    expect(desc).toContain("worktrees");
+    expect(desc).toContain("logs");
+    expect(desc).toContain("patches");
+  });
+});

--- a/src/sandcastle-bridge/index.ts
+++ b/src/sandcastle-bridge/index.ts
@@ -1,0 +1,172 @@
+// Sandcastle bridge — host-side filesystem module owning the lifecycle of the
+// runtime symlink at `<repoRoot>/.sandcastle` → `.tide/`. Sandcastle hardcodes
+// `.sandcastle/{worktrees,logs}/` for its own writes; tide's convention is
+// `.tide/`. The symlink redirects sandcastle's writes into the tide-shaped
+// place so worktree paths line up across runs.
+//
+// Six on-disk shapes are recognised. Only "missing" and "intact" are safe;
+// the other four silently break subsequent `tide run` invocations at the
+// PR-submission step's worktree-collision check. Setup repairs after explicit
+// confirmation; doctor detects only.
+
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+} from "node:fs";
+import path from "node:path";
+
+const SANDCASTLE_DIR_NAME = ".sandcastle";
+const TIDE_DIR_NAME = ".tide";
+/** Relative target so the repo can be moved without breaking the link. */
+const SYMLINK_TARGET = TIDE_DIR_NAME;
+
+export type BridgeState =
+  | { kind: "missing" }
+  | { kind: "intact" }
+  | { kind: "wrong-symlink-target"; target: string }
+  | { kind: "real-dir-empty" }
+  | { kind: "real-dir-with-content"; entries: string[] }
+  | { kind: "regular-file" };
+
+/**
+ * Classify the on-disk shape of `<repoRoot>/.sandcastle`. Pure inspection —
+ * never modifies the filesystem.
+ */
+export function classifyBridge(repoRoot: string): BridgeState {
+  const bridgePath = path.join(repoRoot, SANDCASTLE_DIR_NAME);
+  let stat;
+  try {
+    stat = lstatSync(bridgePath);
+  } catch {
+    return { kind: "missing" };
+  }
+
+  if (stat.isSymbolicLink()) {
+    const target = readlinkSync(bridgePath);
+    if (target === SYMLINK_TARGET) return { kind: "intact" };
+    return { kind: "wrong-symlink-target", target };
+  }
+
+  if (stat.isDirectory()) {
+    if (isTreeEmpty(bridgePath)) return { kind: "real-dir-empty" };
+    return {
+      kind: "real-dir-with-content",
+      entries: readdirSync(bridgePath),
+    };
+  }
+
+  return { kind: "regular-file" };
+}
+
+/**
+ * Walks the tree under `p` and returns true if it contains no non-directory
+ * entries at any depth. Captures the user-incident shape: a real `.sandcastle/`
+ * directory with empty `worktrees/` and `logs/` subdirectories, residue of a
+ * mid-run bridge break.
+ */
+function isTreeEmpty(p: string): boolean {
+  const entries = readdirSync(p, { withFileTypes: true });
+  for (const e of entries) {
+    if (!e.isDirectory()) return false;
+    if (!isTreeEmpty(path.join(p, e.name))) return false;
+  }
+  return true;
+}
+
+function ensureTideDir(repoRoot: string): void {
+  const tideDir = path.join(repoRoot, TIDE_DIR_NAME);
+  if (!existsSync(tideDir)) {
+    mkdirSync(tideDir, { recursive: true });
+  }
+}
+
+function createSymlink(repoRoot: string): void {
+  ensureTideDir(repoRoot);
+  symlinkSync(SYMLINK_TARGET, path.join(repoRoot, SANDCASTLE_DIR_NAME), "dir");
+}
+
+/**
+ * Destructively repair the bridge from any of the four broken states. The
+ * caller must confirm-gate first — passing `intact` or `missing` throws.
+ */
+export function repairBridge(repoRoot: string, state: BridgeState): void {
+  const bridgePath = path.join(repoRoot, SANDCASTLE_DIR_NAME);
+  switch (state.kind) {
+    case "intact":
+      throw new Error(
+        "repairBridge: bridge is already intact — caller must confirm-gate first"
+      );
+    case "missing":
+      throw new Error(
+        "repairBridge: bridge is missing — caller must confirm-gate first"
+      );
+    case "wrong-symlink-target":
+      unlinkSync(bridgePath);
+      createSymlink(repoRoot);
+      return;
+    case "real-dir-empty":
+      rmSync(bridgePath, { recursive: true });
+      createSymlink(repoRoot);
+      return;
+    case "real-dir-with-content":
+      rmSync(bridgePath, { recursive: true, force: true });
+      createSymlink(repoRoot);
+      return;
+    case "regular-file":
+      unlinkSync(bridgePath);
+      createSymlink(repoRoot);
+      return;
+  }
+}
+
+/**
+ * Human-readable summary of the bridge state. Used by setup's confirm prompt
+ * (so the user knows what is about to be deleted) and by doctor's FAIL hint.
+ */
+export function describeBridgeForUser(state: BridgeState): string {
+  switch (state.kind) {
+    case "missing":
+      return "Sandcastle bridge: missing — no .sandcastle entry at repo root.";
+    case "intact":
+      return "Sandcastle bridge: intact (.sandcastle → .tide).";
+    case "wrong-symlink-target":
+      return `Sandcastle bridge: symlink at .sandcastle points at "${state.target}" instead of ".tide".`;
+    case "real-dir-empty":
+      return "Sandcastle bridge: real directory at .sandcastle/ (empty — only empty subdirectories).";
+    case "real-dir-with-content":
+      return `Sandcastle bridge: real directory at .sandcastle/ containing: ${state.entries.join(", ")}.`;
+    case "regular-file":
+      return "Sandcastle bridge: regular file at .sandcastle (expected a symlink).";
+  }
+}
+
+/**
+ * Residual `tide run` safety net: creates the symlink only when the bridge is
+ * `missing`, no-ops when `intact`, throws on every other state with a hint to
+ * run `tide setup`. Replaces the prior silent-bail behavior — a broken bridge
+ * at run time fails fast rather than crashing later at the PR-submission
+ * worktree-collision check.
+ */
+export function createBridgeIfMissing(repoRoot: string): void {
+  const state = classifyBridge(repoRoot);
+  switch (state.kind) {
+    case "intact":
+      return;
+    case "missing":
+      createSymlink(repoRoot);
+      return;
+    case "wrong-symlink-target":
+    case "real-dir-empty":
+    case "real-dir-with-content":
+    case "regular-file":
+      throw new Error(
+        `${describeBridgeForUser(state)} Run \`tide setup\` to repair.`
+      );
+  }
+}


### PR DESCRIPTION
## 🚩 The Problem

- Tide had no first-class concept of the `.sandcastle → .tide` bridge: broken on-disk shapes (wrong symlink target, real directory with stray content, regular file, etc.) would silently survive `tide setup` and only surface much later as a worktree-collision crash inside a `tide run` invocation.
- `tide doctor` had no preflight for the bridge, so users had no fast way to learn that their `.sandcastle` entry was misshapen before running real work.
- `tide run` would silently `return` when it found a non-symlink `.sandcastle` directory, masking a broken bridge as a no-op rather than a failure.
- `tide setup` and `tide doctor` wrote raw lines to `stdout`/`stderr` while `tide run` had already moved to `@clack/prompts`, leaving the three commands visually inconsistent.

## 💡 The Solution

- **Extract** `src/sandcastle-bridge/` — a new host-side module that owns the six on-disk shapes of `<repoRoot>/.sandcastle` (`missing`, `intact`, `wrong-symlink-target`, `real-dir-empty`, `real-dir-with-content`, `regular-file`) and exposes `classifyBridge`, `repairBridge`, `describeBridgeForUser`, and `createBridgeIfMissing`.
- **Deepen** `tide setup` with a new step 1 (before env/config load): `intact`/`missing` is silent (auto-create on missing); the four broken states are described via `log.warn`, gated behind a `clack` confirm, and only then repaired. Decline / cancel exits non-zero with the bridge untouched.
- **Deepen** `tide doctor` with a new detect-only check #1 (zero preconditions — no env, no config, no Linear, no GitHub) that reports `FAIL` with the human-readable bridge state and a `Run \`tide setup\` to repair.` hint.
- **Widen** the residual `tide run` safety net: `createBridgeIfMissing` only creates on `missing`, no-ops on `intact`, and throws fast on every other state instead of silently bailing — replacing the previous `ensureSandcastleSymlink` helper.
- Migrate `tide setup` and `tide doctor` to `@clack/prompts` (`intro`/`outro`, `log.{success,error,info,warn,message}`, `spinner`) so all three top-level commands share one UI vocabulary.

## 🏗 Interface Movements

| Symbol | Old location | New location | Notes |
| --- | --- | --- | --- |
| `classifyBridge`, `repairBridge`, `describeBridgeForUser`, `createBridgeIfMissing`, `BridgeState` | — | `src/sandcastle-bridge/index.ts` | New public module surface. |
| `SetupOptions.stdout`, `SetupOptions.stderr` | `src/cli/setup.ts` | _(removed)_ | Replaced by `@clack/prompts`; tests now assert on return codes / Linear-stub captures. |
| `SetupOptions.confirmBridgeRepair` | — | `src/cli/setup.ts` | New test seam for the destructive bridge-repair confirm prompt. |
| `DoctorOptions.stdout`, `DoctorOptions.stderr` | `src/cli/doctor.ts` | _(removed)_ | Replaced by `@clack/prompts`; tests now assert on return codes and the runner's call log. |
| `DoctorOptions.classifyBridge`, `ClassifyBridgeFn` | — | `src/cli/doctor.ts` | New test seam for the on-disk classifier. |
| `tide setup` step 1 | — | CLI behavior | New mandatory bridge step; declined repair exits 1 before any Linear call. |
| `tide doctor` check #1 | — | CLI behavior | New `sandcastle bridge` step at the top of the matrix. |
| `tide run` broken-bridge handling | _(silent return)_ | _(throws → exit 1 with hint)_ | User-visible failure mode change. |

## 📦 Package Breakdowns

<details>
<summary><code>src/sandcastle-bridge/</code> — new host-side module owning the bridge lifecycle</summary>

- `BridgeState` discriminated union over the six on-disk shapes of `<repoRoot>/.sandcastle`.
- `classifyBridge(repoRoot)` — pure inspection; never touches the filesystem.
- `repairBridge(repoRoot, state)` — destructive; throws if called with `intact` or `missing` so callers must confirm-gate first.
- `describeBridgeForUser(state)` — single source of truth for the human-readable summary used by both setup's confirm prompt and doctor's `FAIL` hint.
- `createBridgeIfMissing(repoRoot)` — residual `tide run` safety net: creates on `missing`, no-ops on `intact`, throws on the four broken states with a `tide setup` hint.
- `isTreeEmpty` — recursive helper that captures the user-incident shape (real `.sandcastle/` with empty `worktrees/` and `logs/` subdirectories) as `real-dir-empty`.

</details>

<details>
<summary><code>src/cli/setup.ts</code> — repair-in-setup step + clack migration</summary>

- New step 1 runs `classifyBridge` before env/config load; `intact`/`missing` is silent (auto-create on missing), the four broken states fire `log.warn(describeBridgeForUser(...))` then a `confirm` prompt before `repairBridge`.
- New `confirmBridgeRepair` test seam bypasses the clack TTY gate in tests; production default uses `confirm` + `isCancel`.
- Drops the `stdout`/`stderr` writer seams from `SetupOptions`; replaces ad-hoc string formatting with `intro`/`outro`, `log.{success,error,info,message}`, and per-step `spinner`s for label and `In Review` provisioning.
- Decline / cancel during the bridge confirm exits 1 with the bridge untouched and the Linear half not invoked.

</details>

<details>
<summary><code>src/cli/doctor.ts</code> — bridge check #1 + clack migration</summary>

- New `sandcastle bridge` step inserted at index 0 of the doctor matrix — zero preconditions and a broken bridge invalidates path assumptions every later check makes.
- Detect-only: returns the bridge description plus `Run \`tide setup\` to repair.` as the `firstFailureHint`; never mutates the filesystem.
- New `classifyBridge` test seam on `DoctorOptions` so tests can assert ordering against the runner's call log without filesystem fixtures.
- Drops the `stdout`/`stderr` writer seams; replaces the `[ok]` / `[FAIL]` line printer with `log.success` / `log.error` and the trailing summary with `outro`.

</details>

<details>
<summary><code>src/cli/run.ts</code> — collapse onto sandcastle-bridge module</summary>

- Removes the local `ensureSandcastleSymlink` helper (and its `node:fs`/`node:path` imports) in favour of `createBridgeIfMissing`.
- Broken-bridge state at run time now exits 1 with the bridge description and a `Run \`tide setup\` to repair.` hint, replacing the prior silent bail.

</details>

<details>
<summary><code>src/cli/setup.test.ts</code>, <code>src/cli/doctor.test.ts</code>, <code>src/sandcastle-bridge/index.test.ts</code> — test updates</summary>

- New `src/sandcastle-bridge/index.test.ts` covers all six `BridgeState` kinds for `classifyBridge`, repair behaviour for the four broken states, the confirm-gate guard on `intact`/`missing`, and `createBridgeIfMissing`'s create / no-op / throw matrix.
- `setup.test.ts` adds bridge-step coverage (silent intact/missing, prompt + repair on each broken state, decline/cancel paths) and switches the existing assertions off stdout/stderr captures onto return codes plus `setupLabels` / `provisionInReviewState` stub captures.
- `doctor.test.ts` adds a `classifyBridge` stub, asserts the new step runs first in the matrix, covers the `FAIL`-with-hint path for each broken state, and rewrites the existing checks to use the runner's call log instead of stdout matching.

</details>

## 🧹 Housekeeping & Secondary Changes

- `STATUS_OK` / `STATUS_FAIL` constants in `src/cli/doctor.ts` removed alongside the raw `[ok]` / `[FAIL]` printer.
- `SummaryRow.created` field dropped in `src/cli/setup.ts` — redundant once rows are partitioned into `created` / `existing` arrays.
