### PR TITLE
feat: filter Linear list/fetch by `[<repo>] ` title prefix

### DIFF
--- a/src/cli/run.test.ts
+++ b/src/cli/run.test.ts
@@ -60,11 +60,13 @@ function makeGhToken(log: CallLog) {
 interface ListPRDsStub {
   prds: PRD[];
   calls: LinearContext[];
+  repoNames: string[];
 }
 
 function makeListPRDs(stub: ListPRDsStub, log: CallLog) {
-  return (ctx: LinearContext): Promise<PRD[]> => {
+  return (ctx: LinearContext, repoName: string): Promise<PRD[]> => {
     stub.calls.push(ctx);
+    stub.repoNames.push(repoName);
     log.events.push("listPRDs");
     return Promise.resolve(stub.prds);
   };
@@ -221,7 +223,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("invokes build before fetching Linear PRDs", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
 
     const code = await tideRun({
       repoRoot,
@@ -248,7 +250,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("build receives the resolved repoRoot and the same stdout/stderr sinks", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
 
     await tideRun({
       repoRoot,
@@ -273,7 +275,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("build failure short-circuits with the build's exit code; PRD fetch never runs", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 2, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
 
     const code = await tideRun({
       repoRoot,
@@ -296,7 +298,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("empty PRD and Standalone Issue lists exit cleanly without invoking the selector", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
     const pickStub: PickRootStub = { pickIndex: 0, calls: 0 };
 
     const code = await tideRun({
@@ -317,6 +319,79 @@ describe("tide run — early gates and Linear PRD selector", () => {
     expect(pickStub.calls).toBe(0);
   });
 
+  test("threads the gh-identity repo name into both Linear list calls (ADR-0012)", async () => {
+    const log: CallLog = { events: [] };
+    const buildStub: BuildStub = { exitCode: 0, calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
+    const standaloneRepoNames: string[] = [];
+
+    await tideRun({
+      repoRoot,
+      stdout: captureStdout,
+      stderr: captureStderr,
+      build: makeBuild(buildStub, log),
+      getGhIdentity: makeGhIdentity(log),
+      getGhToken: makeGhToken(log),
+      listPRDs: makeListPRDs(listStub, log),
+      listStandaloneIssues: (_ctx, repoName) => {
+        standaloneRepoNames.push(repoName);
+        return Promise.resolve([]);
+      },
+      assertInReviewStatePresent: () => Promise.resolve(),
+      baseBranchShellRunner: okBaseBranchRunner,
+    });
+
+    // makeGhIdentity returns { owner: "m1yon", repo: "tide" }; both list
+    // calls must receive that exact repo name as the title-prefix scope.
+    expect(listStub.repoNames).toEqual(["tide"]);
+    expect(standaloneRepoNames).toEqual(["tide"]);
+  });
+
+  test("zero-result outro names the working repo and the `[<repo>] ` prefix form (ADR-0012)", async () => {
+    // When neither PRDs nor Standalone Issues match the prefix, the user
+    // needs to know which repo's prefix tide is filtering by, plus the two
+    // recovery moves (retitle, or create via skill). An empty picker is
+    // never silently confusing.
+    //
+    // clack's `outro` / `log.warn` write directly to `process.stdout`, not
+    // to the injected `stdout` callback — intercept the real stream.
+    const clackChunks: string[] = [];
+    const originalWrite = process.stdout.write.bind(process.stdout);
+    process.stdout.write = (chunk: string | Uint8Array): boolean => {
+      clackChunks.push(typeof chunk === "string" ? chunk : chunk.toString());
+      return true;
+    };
+
+    try {
+      const log: CallLog = { events: [] };
+      const buildStub: BuildStub = { exitCode: 0, calls: [] };
+      const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
+
+      await tideRun({
+        repoRoot,
+        stdout: captureStdout,
+        stderr: captureStderr,
+        build: makeBuild(buildStub, log),
+        getGhIdentity: makeGhIdentity(log),
+        getGhToken: makeGhToken(log),
+        listPRDs: makeListPRDs(listStub, log),
+        listStandaloneIssues: () => Promise.resolve([]),
+        assertInReviewStatePresent: () => Promise.resolve(),
+        baseBranchShellRunner: okBaseBranchRunner,
+      });
+    } finally {
+      process.stdout.write = originalWrite;
+    }
+
+    const out = clackChunks.join("");
+    expect(out).toContain("tide");
+    expect(out).toContain("[tide] ");
+    // The two recovery moves: retitle existing issues, or create a new one
+    // via the triage / to-prd / to-issues skill.
+    expect(out).toMatch(/retitle/i);
+    expect(out).toMatch(/triage|to-prd|to-issues/);
+  });
+
   test("non-empty PRD list invokes pickRoot and dispatches the picked PRD to runQueueAfterPick", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
@@ -326,6 +401,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
         makePRD({ identifier: "ENG-8", title: "Auth migration" }),
       ],
       calls: [],
+      repoNames: [],
     };
     const pickStub: PickRootStub = { pickIndex: 1, calls: 0 };
     const queueCalls: RootRef[] = [];
@@ -365,7 +441,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("non-empty Standalone Issue list invokes pickRoot and dispatches the picked Issue", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
     const pickStub: PickRootStub = { standalonePickIndex: 0, calls: 0 };
     const queueCalls: RootRef[] = [];
 
@@ -402,7 +478,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("listPRDs receives the LINEAR_API_KEY and team key from config", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
 
     await tideRun({
       repoRoot,
@@ -424,7 +500,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("LINEAR_API_KEY is not forwarded into the sandbox (it stays host-side)", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
 
     // We can't observe the sandbox env directly here (the queue path is out
     // of scope for this slice). The narrower assertion: tideRun does not
@@ -448,7 +524,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("build runs after gh-identity is resolved", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
 
     await tideRun({
       repoRoot,
@@ -472,7 +548,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("getGhToken runs after gh-identity and before docker build", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
 
     await tideRun({
       repoRoot,
@@ -501,7 +577,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("getGhToken failure short-circuits before build", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
 
     const code = await tideRun({
       repoRoot,
@@ -551,7 +627,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("preflight refuses to start when `In Review` is missing — fails before build, gh, or Linear fetch", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
     let ghIdentityCalls = 0;
     let ghTokenCalls = 0;
 
@@ -594,7 +670,7 @@ describe("tide run — early gates and Linear PRD selector", () => {
   test("preflight receives the LINEAR_API_KEY and team key from config", async () => {
     const log: CallLog = { events: [] };
     const buildStub: BuildStub = { exitCode: 0, calls: [] };
-    const listStub: ListPRDsStub = { prds: [], calls: [] };
+    const listStub: ListPRDsStub = { prds: [], calls: [], repoNames: [] };
     const calls: { apiKey: string; teamKey: string }[] = [];
 
     await tideRun({
@@ -1158,6 +1234,86 @@ describe("runQueueAfterPick — feature-branch guard", () => {
 
     // Guard didn't fire: fetchSubIssues is reached.
     expect(fetchSubIssuesCalls).toBe(1);
+  });
+
+  test("fetchSubIssues receives ghRepo.repo as the title-prefix scope (ADR-0012)", async () => {
+    // The PRD-root path threads the working repo's GitHub name through to
+    // every Sub-issue fetch — the rebuild call site at every iteration
+    // boundary delegates to the runner, which carries the same `repoName`
+    // it received here.
+    const picked = makePRD({
+      identifier: "ENG-7",
+      branchName: "user/feature/eng-7-search",
+    });
+
+    const fetchCalls: { issueId: string; repoName: string }[] = [];
+
+    await runQueueAfterPick({
+      picked: prdRoot(picked),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: (_ctx, issueId, repoName) => {
+        fetchCalls.push({ issueId, repoName });
+        return Promise.resolve([]);
+      },
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 0, flipped: 0, processed: [] }),
+      runPrTailStep: () =>
+        Promise.resolve({
+          outcome: { kind: "opted-out" },
+          outroMessage: "x",
+          exitCode: 0,
+        } satisfies PrTailStepResult),
+      confirmRun: () => Promise.resolve(true),
+      confirmPr: () => Promise.resolve(true),
+      transitionRootToInProgress: () => Promise.resolve(),
+    });
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]?.repoName).toBe("widget");
+  });
+
+  test("Standalone Issue children-validation fetch also receives ghRepo.repo", async () => {
+    // The Standalone-Issue "no Linear children" check uses the same
+    // fetchSubIssues seam — apply the prefix filter uniformly.
+    const issue = makeStandaloneIssue({
+      identifier: "ENG-7",
+      branchName: "user/eng-7",
+    });
+
+    const fetchCalls: { issueId: string; repoName: string }[] = [];
+
+    await runQueueAfterPick({
+      picked: standaloneRoot(issue),
+      ghRepo: { owner: "acme", repo: "widget" },
+      baseBranch: "master",
+      linearCtx: { apiKey: "lk", teamKey: "ENG" },
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      fetchSubIssues: (_ctx, issueId, repoName) => {
+        fetchCalls.push({ issueId, repoName });
+        return Promise.resolve([]);
+      },
+      runIssueQueue: () =>
+        Promise.resolve({ completed: 1, flipped: 0, processed: [] }),
+      runPrTailStep: () =>
+        Promise.resolve({
+          outcome: { kind: "opted-out" },
+          outroMessage: "x",
+          exitCode: 0,
+        } satisfies PrTailStepResult),
+      confirmRun: () => Promise.resolve(true),
+      confirmPr: () => Promise.resolve(true),
+      transitionRootToInProgress: () => Promise.resolve(),
+    });
+
+    expect(fetchCalls).toHaveLength(1);
+    expect(fetchCalls[0]?.repoName).toBe("widget");
   });
 });
 

--- a/src/cli/run.ts
+++ b/src/cli/run.ts
@@ -83,6 +83,25 @@ import {
 
 const READY_FOR_HUMAN = "ready-for-human";
 
+/**
+ * Build the user-facing message tide prints when a Linear list query
+ * returns zero issues for the working repo. Names the repo and surfaces
+ * the two recovery moves so an empty picker / queue is never silently
+ * confusing (ADR-0012).
+ */
+function emptyListMessage(
+  kind: "PRD" | "Standalone Issue" | "sub-issue" | "root",
+  repoName: string
+): string {
+  const noun = kind === "root" ? "PRD or Standalone Issue" : kind;
+  return (
+    `No ${noun}(s) for repo "${repoName}". ` +
+    `Tide filters Linear titles by the \`[${repoName}] \` prefix. ` +
+    `Either retitle existing Linear issues to start with that prefix, ` +
+    `or create one with the triage / to-prd / to-issues skill.`
+  );
+}
+
 export { buildOrderedQueue };
 export type { BuildOrderedQueueResult, OrderedSubIssue };
 
@@ -98,9 +117,12 @@ export interface RunOptions {
   /** gh-token resolver. Tests stub this to avoid spawning `gh`. */
   getGhToken?: (options: GetGhTokenOptions) => Promise<string>;
   /** Linear PRD list fetcher. Tests stub this to avoid hitting Linear. */
-  listPRDs?: (ctx: LinearContext) => Promise<PRD[]>;
+  listPRDs?: (ctx: LinearContext, repoName: string) => Promise<PRD[]>;
   /** Linear Standalone Issue list fetcher. Tests stub this. */
-  listStandaloneIssues?: (ctx: LinearContext) => Promise<StandaloneIssue[]>;
+  listStandaloneIssues?: (
+    ctx: LinearContext,
+    repoName: string
+  ) => Promise<StandaloneIssue[]>;
   /**
    * Linear `"In Review"` state preflight assertion. Tests stub this to
    * avoid hitting Linear. Defaults to `linear.assertInReviewStatePresent`.
@@ -135,8 +157,13 @@ export interface RunQueueAfterPickOptions {
   sandboxEnv: Record<string, string>;
   /** Test seam — defaults to `linear.fetchSubIssues`. Used both to build
    * the queue for PRD roots and to validate the "no children" rule for
-   * Standalone Issue roots. */
-  fetchSubIssues?: (ctx: LinearContext, issueId: string) => Promise<SubIssue[]>;
+   * Standalone Issue roots. The `repoName` argument applies the repo-prefix
+   * scope filter from ADR-0012. */
+  fetchSubIssues?: (
+    ctx: LinearContext,
+    issueId: string,
+    repoName: string
+  ) => Promise<SubIssue[]>;
   /** Test seam — defaults to the runner module's `runIssueQueue`. */
   runIssueQueue?: (opts: RunIssueQueueOptions) => Promise<RunIssueQueueResult>;
   /** Test seam — defaults to the in-module `runPrTailStep`. */
@@ -380,7 +407,11 @@ export async function runQueueAfterPick(
     subSpin.start("Fetching sub-issues from Linear");
     let subIssues: SubIssue[];
     try {
-      subIssues = await fetchSubIssuesFn(opts.linearCtx, root.id);
+      subIssues = await fetchSubIssuesFn(
+        opts.linearCtx,
+        root.id,
+        opts.ghRepo.repo
+      );
     } catch (err) {
       subSpin.stop("Linear sub-issue fetch failed");
       const msg = err instanceof Error ? err.message : String(err);
@@ -389,6 +420,10 @@ export async function runQueueAfterPick(
       return 1;
     }
     subSpin.stop(`Fetched ${String(subIssues.length)} sub-issue(s)`);
+
+    if (subIssues.length === 0) {
+      log.warn(emptyListMessage("sub-issue", opts.ghRepo.repo));
+    }
 
     const queue = buildOrderedQueue(subIssues);
     if (queue.kind === "error") {
@@ -450,7 +485,11 @@ export async function runQueueAfterPick(
     childSpin.start("Verifying Standalone Issue has no Linear children");
     let children: SubIssue[];
     try {
-      children = await fetchSubIssuesFn(opts.linearCtx, root.id);
+      children = await fetchSubIssuesFn(
+        opts.linearCtx,
+        root.id,
+        opts.ghRepo.repo
+      );
     } catch (err) {
       childSpin.stop("Linear child fetch failed");
       const msg = err instanceof Error ? err.message : String(err);
@@ -497,6 +536,7 @@ export async function runQueueAfterPick(
     repoRoot: opts.repoRoot,
     config: opts.config,
     sandboxEnv: opts.sandboxEnv,
+    repoName: opts.ghRepo.repo,
   });
 
   if (queueResult.abortedAt) {
@@ -735,15 +775,17 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
 
   intro("tide run");
 
-  // Fetch PRDs and Standalone Issues in parallel.
+  // Fetch PRDs and Standalone Issues in parallel. Both list calls apply the
+  // `[<repoName>] ` title-prefix scope filter (ADR-0012) — wrong-repo and
+  // unprefixed issues are invisible.
   const fetchSpin = spinner();
   fetchSpin.start("Fetching PRDs and Standalone Issues from Linear");
   let prds: PRD[];
   let standaloneIssues: StandaloneIssue[];
   try {
     [prds, standaloneIssues] = await Promise.all([
-      listPRDsFn(linearCtx),
-      listStandaloneIssuesFn(linearCtx),
+      listPRDsFn(linearCtx, ghIdentity.repo),
+      listStandaloneIssuesFn(linearCtx, ghIdentity.repo),
     ]);
   } catch (err) {
     fetchSpin.stop("Linear fetch failed");
@@ -755,10 +797,14 @@ export async function tideRun(options: RunOptions = {}): Promise<number> {
     `Fetched ${String(prds.length)} PRD(s), ${String(standaloneIssues.length)} Standalone Issue(s)`
   );
 
+  if (prds.length === 0) {
+    log.warn(emptyListMessage("PRD", ghIdentity.repo));
+  }
+  if (standaloneIssues.length === 0) {
+    log.warn(emptyListMessage("Standalone Issue", ghIdentity.repo));
+  }
   if (prds.length === 0 && standaloneIssues.length === 0) {
-    outro(
-      "No roots to run. Author a PRD with `ready-for-agent` sub-issues, or a Standalone Issue with the `ready-for-agent` label, in Linear."
-    );
+    outro(emptyListMessage("root", ghIdentity.repo));
     return 0;
   }
 

--- a/src/linear/index.test.ts
+++ b/src/linear/index.test.ts
@@ -13,6 +13,7 @@ import {
   pickWorkflowStateByType,
   postComment,
   provisionInReviewState,
+  repoTitlePrefix,
   setupLabels,
   transitionToDone,
   transitionToInProgress,
@@ -171,6 +172,23 @@ describe("linear.setupLabels", () => {
     }
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toMatch(/ready-for-agent/);
+  });
+});
+
+describe("linear.repoTitlePrefix", () => {
+  test("renders the canonical `[<repoName>] ` form (open-bracket, repo, close-bracket, single space)", () => {
+    expect(repoTitlePrefix("tide")).toBe("[tide] ");
+  });
+
+  test("trailing space is exact — no whitespace tolerance inside the brackets either", () => {
+    // Exact byte form is the contract (ADR-0012). A regression that strips
+    // the trailing space would silently match a `[tide]bug` title; a
+    // regression that inserts whitespace inside would silently fail to
+    // match `[tide] bug`.
+    const p = repoTitlePrefix("tide");
+    expect(p.endsWith(" ")).toBe(true);
+    expect(p).not.toMatch(/\[\s/);
+    expect(p).not.toMatch(/\s\]/);
   });
 });
 
@@ -368,7 +386,7 @@ describe("linear.listPRDs", () => {
       childCountsByParent: {},
     });
 
-    await listPRDs(ctx, stub.client);
+    await listPRDs(ctx, "tide", stub.client);
 
     // First `issues` call is the PRD list.
     const filter = stub.issuesFilters[0];
@@ -430,7 +448,7 @@ describe("linear.listPRDs", () => {
       },
     });
 
-    const prds = await listPRDs(ctx, stub.client);
+    const prds = await listPRDs(ctx, "tide", stub.client);
 
     expect(prds.map((p) => p.identifier)).toEqual(["ENG-1"]);
   });
@@ -472,7 +490,7 @@ describe("linear.listPRDs", () => {
       },
     });
 
-    const prds = await listPRDs(ctx, stub.client);
+    const prds = await listPRDs(ctx, "tide", stub.client);
 
     expect(prds).toHaveLength(2);
     const a = prds[0];
@@ -512,7 +530,7 @@ describe("linear.listPRDs", () => {
       },
     });
 
-    await listPRDs(ctx, stub.client);
+    await listPRDs(ctx, "tide", stub.client);
 
     // The first issues call is the PRD list; subsequent calls are child counts.
     const childCalls = stub.issuesFilters.slice(1);
@@ -531,7 +549,7 @@ describe("linear.listPRDs", () => {
     const stub = buildListPRDsStub({ knownTeamKeys: ["OTHER"] });
     let caught: unknown = null;
     try {
-      await listPRDs(ctx, stub.client);
+      await listPRDs(ctx, "tide", stub.client);
     } catch (err) {
       caught = err;
     }
@@ -541,7 +559,7 @@ describe("linear.listPRDs", () => {
 
   test("returns an empty list when no PRDs match", async () => {
     const stub = buildListPRDsStub({ prdNodes: [] });
-    const prds = await listPRDs(ctx, stub.client);
+    const prds = await listPRDs(ctx, "tide", stub.client);
     expect(prds).toEqual([]);
   });
 
@@ -561,8 +579,47 @@ describe("linear.listPRDs", () => {
       states: [],
       childCountsByParent: { "issue-x": { "ready-for-agent": 1 } },
     });
-    const prds = await listPRDs(ctx, stub.client);
+    const prds = await listPRDs(ctx, "tide", stub.client);
     expect(prds[0]?.state).toBe("");
+  });
+
+  test("applies the `[<repoName>] ` title-prefix scope filter (ADR-0012)", async () => {
+    // The PRD list call must filter by `title.startsWith("[<repoName>] ")` so
+    // wrong-repo and unprefixed PRDs are invisible to the picker, the queue
+    // build, and the queue rebuild. Exact form: open-bracket, repo name,
+    // close-bracket, single space — no whitespace tolerance.
+    const stub = buildListPRDsStub();
+    await listPRDs(ctx, "tide", stub.client);
+    expect(stub.issuesFilters[0]?.title?.startsWith).toBe("[tide] ");
+  });
+
+  test("title-prefix filter only applies to the PRD list, not the child-count queries", async () => {
+    // The child-count queries are scoped by parent.id.eq, not by team — they
+    // count direct children of the already-selected PRD. Re-applying the
+    // prefix filter there would silently drop valid sub-issue counts, which
+    // is the wrong invariant. The Sub-issue list call (`fetchSubIssues`) has
+    // its own filter — see those tests.
+    const stub = buildListPRDsStub({
+      prdNodes: [
+        {
+          id: "issue-A",
+          identifier: "ENG-7",
+          title: "x",
+          stateId: undefined,
+          branchName: "b",
+          url: "u",
+          updatedAt: new Date(0),
+        },
+      ],
+      childCountsByParent: {
+        "issue-A": { "ready-for-agent": 1, "ready-for-human": 1 },
+      },
+    });
+    await listPRDs(ctx, "tide", stub.client);
+    const childCalls = stub.issuesFilters.slice(1);
+    for (const f of childCalls) {
+      expect(f.title).toBeUndefined();
+    }
   });
 });
 
@@ -616,7 +673,7 @@ describe("linear.listStandaloneIssues", () => {
   test("queries for ready-for-agent issues with no parent and no `prd` label, in non-terminal states", async () => {
     const stub = buildListStandaloneStub();
 
-    await listStandaloneIssues(ctx, stub.client);
+    await listStandaloneIssues(ctx, "tide", stub.client);
 
     const filter = stub.issuesFilters[0];
     expect(filter).toBeDefined();
@@ -676,7 +733,7 @@ describe("linear.listStandaloneIssues", () => {
       ],
     });
 
-    const issues = await listStandaloneIssues(ctx, stub.client);
+    const issues = await listStandaloneIssues(ctx, "tide", stub.client);
 
     expect(issues).toHaveLength(1);
     const a = issues[0];
@@ -691,7 +748,7 @@ describe("linear.listStandaloneIssues", () => {
 
   test("returns an empty list when no issues match", async () => {
     const stub = buildListStandaloneStub({ issueNodes: [] });
-    const issues = await listStandaloneIssues(ctx, stub.client);
+    const issues = await listStandaloneIssues(ctx, "tide", stub.client);
     expect(issues).toEqual([]);
   });
 
@@ -710,7 +767,7 @@ describe("linear.listStandaloneIssues", () => {
       ],
       states: [],
     });
-    const issues = await listStandaloneIssues(ctx, stub.client);
+    const issues = await listStandaloneIssues(ctx, "tide", stub.client);
     expect(issues[0]?.state).toBe("");
   });
 
@@ -718,12 +775,21 @@ describe("linear.listStandaloneIssues", () => {
     const stub = buildListStandaloneStub({ knownTeamKeys: ["OTHER"] });
     let caught: unknown = null;
     try {
-      await listStandaloneIssues(ctx, stub.client);
+      await listStandaloneIssues(ctx, "tide", stub.client);
     } catch (err) {
       caught = err;
     }
     expect(caught).toBeInstanceOf(Error);
     expect((caught as Error).message).toMatch(/team with key "ENG" not found/);
+  });
+
+  test("applies the `[<repoName>] ` title-prefix scope filter (ADR-0012)", async () => {
+    // Mirrors the listPRDs filter: wrong-repo and unprefixed Standalone
+    // Issues are invisible. Exact form: open-bracket, repo name,
+    // close-bracket, single space.
+    const stub = buildListStandaloneStub();
+    await listStandaloneIssues(ctx, "tide", stub.client);
+    expect(stub.issuesFilters[0]?.title?.startsWith).toBe("[tide] ");
   });
 });
 
@@ -782,7 +848,7 @@ describe("linear.fetchSubIssues", () => {
       },
     }));
 
-    const subs = await fetchSubIssues(ctx, "prd-uuid", stub.request);
+    const subs = await fetchSubIssues(ctx, "prd-uuid", "tide", stub.request);
 
     expect(subs).toHaveLength(2);
     const a = subs[0];
@@ -808,17 +874,20 @@ describe("linear.fetchSubIssues", () => {
       issue: { children: { nodes: [] } },
     }));
 
-    await fetchSubIssues(ctx, "the-prd-uuid", stub.request);
+    await fetchSubIssues(ctx, "the-prd-uuid", "tide", stub.request);
 
     expect(stub.calls).toHaveLength(1);
-    expect(stub.calls[0]?.variables).toEqual({ id: "the-prd-uuid" });
+    expect(stub.calls[0]?.variables).toEqual({
+      id: "the-prd-uuid",
+      filter: { title: { startsWith: "[tide] " } },
+    });
   });
 
   test("returns an empty list when the PRD has no children", async () => {
     const stub = makeGqlStub(() => ({
       issue: { children: { nodes: [] } },
     }));
-    const subs = await fetchSubIssues(ctx, "lonely-prd", stub.request);
+    const subs = await fetchSubIssues(ctx, "lonely-prd", "tide", stub.request);
     expect(subs).toEqual([]);
   });
 
@@ -826,7 +895,7 @@ describe("linear.fetchSubIssues", () => {
     const stub = makeGqlStub(() => ({ issue: null }));
     let caught: unknown = null;
     try {
-      await fetchSubIssues(ctx, "missing-uuid", stub.request);
+      await fetchSubIssues(ctx, "missing-uuid", "tide", stub.request);
     } catch (err) {
       caught = err;
     }
@@ -834,6 +903,30 @@ describe("linear.fetchSubIssues", () => {
     expect((caught as Error).message).toMatch(
       /PRD with id "missing-uuid" not found/
     );
+  });
+
+  test("applies the `[<repoName>] ` title-prefix scope filter via the children's `filter` arg (ADR-0012)", async () => {
+    // The Sub-issue fetch (used both at initial queue build and at every
+    // iteration boundary by the queue rebuild) must filter by
+    // `title.startsWith("[<repoName>] ")` so a mistitled or wrong-repo
+    // sub-issue under a `[<repoName>] ` PRD is not queued and is not
+    // absorbed by the rebuild.
+    const stub = makeGqlStub(() => ({
+      issue: { children: { nodes: [] } },
+    }));
+
+    await fetchSubIssues(ctx, "prd-uuid", "tide", stub.request);
+
+    expect(stub.calls).toHaveLength(1);
+    expect(stub.calls[0]?.variables).toEqual({
+      id: "prd-uuid",
+      filter: { title: { startsWith: "[tide] " } },
+    });
+    // The query body must also accept a `$filter: IssueFilter` variable and
+    // pass it through to `children(... filter: $filter)`. Verify the literal
+    // shape so a regression on the GraphQL document is caught here.
+    expect(stub.calls[0]?.query).toMatch(/\$filter:\s*IssueFilter/);
+    expect(stub.calls[0]?.query).toMatch(/children\([^)]*filter:\s*\$filter/);
   });
 
   test("falls back gracefully when state is null", async () => {
@@ -853,7 +946,7 @@ describe("linear.fetchSubIssues", () => {
         },
       },
     }));
-    const subs = await fetchSubIssues(ctx, "prd", stub.request);
+    const subs = await fetchSubIssues(ctx, "prd", "tide", stub.request);
     expect(subs[0]?.state).toBe("");
     expect(subs[0]?.stateType).toBe("");
   });

--- a/src/linear/index.ts
+++ b/src/linear/index.ts
@@ -1,14 +1,17 @@
 // Linear SDK facade for the Linear-native flow. Operations:
-//   - listPRDs(ctx): list every issue on the configured team that carries
-//     the `prd` label and has at least one direct sub-issue carrying
+//   - listPRDs(ctx, repoName): list every issue on the configured team that
+//     carries the `prd` label, whose title starts with the `[<repoName>] `
+//     prefix, and has at least one direct sub-issue carrying
 //     `ready-for-agent`, in a non-terminal workflow state. Each entry
 //     carries the count of its direct sub-issues split by
 //     `ready-for-agent` / `ready-for-human` label.
-//   - listStandaloneIssues(ctx): list every issue on the configured team
-//     that carries `ready-for-agent`, has no Linear parent, and does not
-//     carry the `prd` label, in a non-terminal workflow state.
-//   - fetchSubIssues(ctx, prdId): direct Linear children of a given PRD, with
-//     identifier, title, workflow state, label set, and blockedBy relations.
+//   - listStandaloneIssues(ctx, repoName): list every issue on the
+//     configured team whose title starts with `[<repoName>] `, that
+//     carries `ready-for-agent`, has no Linear parent, and does not carry
+//     the `prd` label, in a non-terminal workflow state.
+//   - fetchSubIssues(ctx, prdId, repoName): direct Linear children of a
+//     given PRD whose titles start with `[<repoName>] `, with identifier,
+//     title, workflow state, label set, and blockedBy relations.
 //   - fetchIssueContent(ctx, issueId): the issue's description (markdown
 //     body) and the bodies of its comments. Used to hydrate per-iteration
 //     prompt args.
@@ -25,6 +28,13 @@
 //
 // Workflow-state filtering uses `state.type` (not name) so per-team renames
 // of "In Progress" / "Done" don't slip terminal issues through.
+//
+// The repo prefix (`[<repoName>] ` — open-bracket, repo name, close-bracket,
+// single space) on Linear titles is the scope filter that lets one Linear
+// team back many repos (ADR-0012). The three list/fetch functions consume
+// it as a server-side `title.startsWith` clause; setup/doctor operations
+// (label provisioning, workflow-state checks) are repo-agnostic and don't
+// need it.
 //
 // Credentials: `apiKey` is passed in (loaded from `<repoRoot>/.tide/.env` by
 // the caller). The team key is also injected so this module is repo-agnostic.
@@ -162,6 +172,15 @@ export function pickWorkflowStateByName(
 }
 
 /**
+ * Build the `[<repoName>] ` title prefix tide filters Linear queries by
+ * (ADR-0012). Exact form: open-bracket, repo name, close-bracket, single
+ * space — no whitespace tolerance inside the brackets.
+ */
+export function repoTitlePrefix(repoName: string): string {
+  return `[${repoName}] `;
+}
+
+/**
  * Filter shape consumed by `listPRDs` via the SDK's `issues` method. The
  * production caller passes the real `LinearClient`; tests pass a hand-rolled
  * stub matching the same shape.
@@ -172,6 +191,7 @@ export interface ListPRDsIssueFilter {
   labels?: { name: { eq: string } };
   and?: ListPRDsIssueFilter[];
   state?: { type: { in: string[] } };
+  title?: { startsWith: string };
 }
 
 /**
@@ -189,6 +209,7 @@ export interface ListStandaloneIssuesFilter {
     | { some: { name: { eq: string } } }
     | { every: { name: { neq: string } } };
   and?: ListStandaloneIssuesFilter[];
+  title?: { startsWith: string };
 }
 
 interface ListPRDsIssueNode {
@@ -223,20 +244,24 @@ export interface ListPRDsClient {
 }
 
 /**
- * List every PRD (issue tagged with `prd` on the configured team, in a
- * non-terminal workflow state, with at least one direct sub-issue carrying
- * `ready-for-agent`) ordered by `updatedAt` desc. Each PRD carries the count
- * of its direct sub-issues split by `ready-for-agent` / `ready-for-human`
- * label.
+ * List every PRD (issue tagged with `prd` on the configured team, whose
+ * title starts with `[<repoName>] `, in a non-terminal workflow state,
+ * with at least one direct sub-issue carrying `ready-for-agent`) ordered
+ * by `updatedAt` desc. Each PRD carries the count of its direct sub-issues
+ * split by `ready-for-agent` / `ready-for-human` label.
  *
  * Standalone PRDs — `prd`-labeled issues with zero `ready-for-agent`
  * direct children — are filtered out so they don't clutter the picker.
+ *
+ * The `[<repoName>] ` prefix is the team↔repo scope filter from ADR-0012.
+ * Wrong-repo and unprefixed PRDs are invisible.
  *
  * `_client` is a test seam — production callers omit it and the real
  * `LinearClient` is constructed from `ctx.apiKey`.
  */
 export async function listPRDs(
   ctx: LinearContext,
+  repoName: string,
   _client?: ListPRDsClient
 ): Promise<PRD[]> {
   const c: ListPRDsClient = _client ?? client(ctx.apiKey);
@@ -248,6 +273,7 @@ export async function listPRDs(
         team: { id: { eq: teamId } },
         and: [{ labels: { name: { eq: PRD_LABEL } } }],
         state: { type: { in: [...NON_TERMINAL_STATE_TYPES] } },
+        title: { startsWith: repoTitlePrefix(repoName) },
       },
       orderBy: PaginationOrderBy.UpdatedAt,
     }),
@@ -323,14 +349,19 @@ export interface ListStandaloneIssuesClient {
 
 /**
  * List every Standalone Issue (issue tagged with `ready-for-agent` on the
- * configured team, with no Linear parent, not carrying the `prd` label, in
- * a non-terminal workflow state) ordered by `updatedAt` desc.
+ * configured team, whose title starts with `[<repoName>] `, with no Linear
+ * parent, not carrying the `prd` label, in a non-terminal workflow state)
+ * ordered by `updatedAt` desc.
+ *
+ * The `[<repoName>] ` prefix is the team↔repo scope filter from ADR-0012.
+ * Wrong-repo and unprefixed Standalone Issues are invisible.
  *
  * `_client` is a test seam — production callers omit it and the real
  * `LinearClient` is constructed from `ctx.apiKey`.
  */
 export async function listStandaloneIssues(
   ctx: LinearContext,
+  repoName: string,
   _client?: ListStandaloneIssuesClient
 ): Promise<StandaloneIssue[]> {
   const c: ListStandaloneIssuesClient = _client ?? client(ctx.apiKey);
@@ -346,6 +377,7 @@ export async function listStandaloneIssues(
           { labels: { some: { name: { eq: READY_FOR_AGENT_LABEL } } } },
           { labels: { every: { name: { neq: PRD_LABEL } } } },
         ],
+        title: { startsWith: repoTitlePrefix(repoName) },
       },
       orderBy: PaginationOrderBy.UpdatedAt,
     }),
@@ -649,10 +681,10 @@ export interface SubIssue {
 }
 
 const SUB_ISSUES_QUERY = /* GraphQL */ `
-  query TideSubIssues($id: String!) {
+  query TideSubIssues($id: String!, $filter: IssueFilter) {
     issue(id: $id) {
       id
-      children(first: 250) {
+      children(first: 250, filter: $filter) {
         nodes {
           id
           identifier
@@ -695,11 +727,17 @@ interface SubIssueGqlNode {
 }
 
 /**
- * Fetch the direct Linear children of `prdId` (an issue UUID). Each entry
- * carries the data the runner needs to topo-sort and dispatch: identifier,
- * title, workflow-state name + type, label names, and `blockedBy`
- * identifiers. Only relations of type `"blocks"` populate `blockedBy`;
- * `"related"` and `"duplicate"` are ignored.
+ * Fetch the direct Linear children of `prdId` (an issue UUID) whose titles
+ * start with `[<repoName>] `. Each entry carries the data the runner needs
+ * to topo-sort and dispatch: identifier, title, workflow-state name + type,
+ * label names, and `blockedBy` identifiers. Only relations of type
+ * `"blocks"` populate `blockedBy`; `"related"` and `"duplicate"` are
+ * ignored.
+ *
+ * The `[<repoName>] ` prefix is the team↔repo scope filter from ADR-0012,
+ * applied at every iteration boundary's queue rebuild — wrong-repo and
+ * unprefixed Sub-issues are invisible to both the initial queue build and
+ * the rebuild.
  *
  * Throws when the PRD id does not resolve. Sub-issues whose blocker
  * relation lacks an issue payload (deleted source) are skipped.
@@ -709,12 +747,16 @@ interface SubIssueGqlNode {
 export async function fetchSubIssues(
   ctx: LinearContext,
   prdId: string,
+  repoName: string,
   _request?: LinearGqlRequest
 ): Promise<SubIssue[]> {
   const request = _request ?? rawRequest(ctx.apiKey);
   const data = await request<{
     issue: { children: { nodes: SubIssueGqlNode[] } } | null;
-  }>(SUB_ISSUES_QUERY, { id: prdId });
+  }>(SUB_ISSUES_QUERY, {
+    id: prdId,
+    filter: { title: { startsWith: repoTitlePrefix(repoName) } },
+  });
   if (!data.issue) {
     throw new Error(`Linear PRD with id "${prdId}" not found.`);
   }

--- a/src/runner/index.ts
+++ b/src/runner/index.ts
@@ -181,6 +181,11 @@ export interface RunIssueQueueOptions {
   // Env map intended for the docker sandbox. Caller is responsible for
   // stripping LINEAR_API_KEY before passing this in.
   sandboxEnv: Record<string, string>;
+  // Working repo's GitHub name (from gh-identity). Threaded into every
+  // mid-run `fetchSubIssues` call as the `[<repoName>] ` title-prefix
+  // scope filter (ADR-0012) — wrong-repo and unprefixed Sub-issues are
+  // invisible to the queue rebuild and never absorbed.
+  repoName: string;
   /** Test seam — defaults to `linear.fetchIssueContent`. */
   fetchIssueContent?: (
     ctx: LinearContext,
@@ -221,8 +226,13 @@ export interface RunIssueQueueOptions {
   shellRunner?: ShellRunner;
   /** Test seam — defaults to `linear.fetchSubIssues`. Called at every
    * iteration boundary on PRD roots to absorb mid-run additions. See
-   * ADR-0010. Standalone roots never call this. */
-  fetchSubIssues?: (ctx: LinearContext, prdId: string) => Promise<SubIssue[]>;
+   * ADR-0010. Standalone roots never call this. The `repoName` argument
+   * applies the repo-prefix scope filter from ADR-0012. */
+  fetchSubIssues?: (
+    ctx: LinearContext,
+    prdId: string,
+    repoName: string
+  ) => Promise<SubIssue[]>;
 }
 
 export interface RunIssueQueueResult {
@@ -423,6 +433,22 @@ type RebuildOutcome =
   | { kind: "abort"; identifier: string; reason: string };
 
 /**
+ * User-facing warning when an iteration-boundary `fetchSubIssues` returns
+ * zero matching Sub-issues for the working repo. The runner keeps the
+ * previous boundary's queue and continues; this surfaces the most likely
+ * cause (a typo'd or unprefixed title under a `[<repoName>] ` PRD), so an
+ * empty rebuild is never silently confusing (ADR-0012).
+ */
+function emptySubIssueRebuildMessage(repoName: string): string {
+  return (
+    `Queue rebuild returned no sub-issues for repo "${repoName}". ` +
+    `Tide filters Linear titles by the \`[${repoName}] \` prefix. ` +
+    `Either retitle existing Linear issues to start with that prefix, ` +
+    `or create one with the triage / to-prd / to-issues skill.`
+  );
+}
+
+/**
  * Re-fetch the picked PRD's direct children and rebuild the topo-ordered
  * queue. The fetch result is fed to `buildOrderedQueue` unmodified — its
  * existing closed-blocker / external-blocker / cycle handling subsumes the
@@ -445,15 +471,27 @@ type RebuildOutcome =
 async function rebuildQueueAtBoundary(args: {
   linearCtx: LinearContext;
   prdId: string;
-  fetchSubIssues: (ctx: LinearContext, prdId: string) => Promise<SubIssue[]>;
+  repoName: string;
+  fetchSubIssues: (
+    ctx: LinearContext,
+    prdId: string,
+    repoName: string
+  ) => Promise<SubIssue[]>;
   knownIdentifiers: Set<string>;
 }): Promise<RebuildOutcome> {
   let subIssues: SubIssue[];
   try {
-    subIssues = await args.fetchSubIssues(args.linearCtx, args.prdId);
+    subIssues = await args.fetchSubIssues(
+      args.linearCtx,
+      args.prdId,
+      args.repoName
+    );
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     return { kind: "fetch-failed", reason: msg };
+  }
+  if (subIssues.length === 0) {
+    log.warn(emptySubIssueRebuildMessage(args.repoName));
   }
 
   // Don't pre-filter `handled` identifiers from the candidate set:
@@ -550,6 +588,7 @@ export async function runIssueQueue(
     repoRoot,
     config,
     sandboxEnv,
+    repoName,
   } = options;
   const fetchIssueContentFn =
     options.fetchIssueContent ?? defaultFetchIssueContent;
@@ -859,6 +898,7 @@ export async function runIssueQueue(
         const outcome = await rebuildQueueAtBoundary({
           linearCtx,
           prdId: root.id,
+          repoName,
           fetchSubIssues: fetchSubIssuesFn,
           knownIdentifiers,
         });

--- a/src/runner/runner.test.ts
+++ b/src/runner/runner.test.ts
@@ -118,6 +118,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => {
         events.push("fetchContent");
@@ -168,6 +169,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () =>
         Promise.resolve(
           asSubIssues([
@@ -281,6 +283,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () =>
         Promise.resolve(
           asSubIssues([
@@ -382,6 +385,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
@@ -417,6 +421,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => {
@@ -481,6 +486,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => {
@@ -544,6 +550,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
@@ -594,6 +601,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
@@ -648,6 +656,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () =>
         Promise.resolve(
           asSubIssues([
@@ -711,6 +720,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => {
@@ -745,6 +755,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () =>
         Promise.resolve(
           asSubIssues([
@@ -796,6 +807,7 @@ describe("runIssueQueue — DONE signal + Linear transitions", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: (_ctx, issueId) => {
@@ -827,6 +839,7 @@ describe("runIssueQueue — prompt args + sandcastle wiring", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () =>
         Promise.resolve(makeIssueContent({ identifier: "ENG-7" })),
@@ -867,6 +880,7 @@ describe("runIssueQueue — prompt args + sandcastle wiring", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
@@ -899,6 +913,7 @@ describe("runIssueQueue — prompt args + sandcastle wiring", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
@@ -957,6 +972,7 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
@@ -984,6 +1000,7 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
@@ -1032,6 +1049,7 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
@@ -1071,6 +1089,7 @@ describe("runIssueQueue — host-side `git push` after every iteration", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () =>
         Promise.resolve(
           asSubIssues([
@@ -1128,6 +1147,7 @@ describe("runIssueQueue — Standalone Issue root: skip Done transition", () => 
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchIssueContent: () => {
         events.push("fetchContent");
         return Promise.resolve(makeIssueContent({ identifier: "ENG-7" }));
@@ -1172,6 +1192,7 @@ describe("runIssueQueue — Standalone Issue root: skip Done transition", () => 
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: (_ctx, issueId) => {
         events.push(`inProgress:${issueId}`);
@@ -1233,6 +1254,7 @@ describe("runIssueQueue — Standalone Issue root: skip Done transition", () => 
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => Promise.resolve([]),
       fetchIssueContent: () => Promise.resolve(makeIssueContent()),
       transitionToInProgress: () => Promise.resolve(),
@@ -1263,6 +1285,7 @@ describe("runIssueQueue — mid-run queue rebuild (ADR-0010)", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () =>
         Promise.resolve(
           asSubIssues([
@@ -1302,6 +1325,7 @@ describe("runIssueQueue — mid-run queue rebuild (ADR-0010)", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => {
         fetchCount += 1;
         // After iteration 1, the human added ENG-2 in Linear's UI.
@@ -1374,6 +1398,7 @@ describe("runIssueQueue — mid-run queue rebuild (ADR-0010)", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => {
         fetchCount += 1;
         if (fetchCount === 1) {
@@ -1450,6 +1475,7 @@ describe("runIssueQueue — mid-run queue rebuild (ADR-0010)", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => {
         fetchCount += 1;
         if (fetchCount === 1) {
@@ -1547,6 +1573,7 @@ describe("runIssueQueue — mid-run queue rebuild (ADR-0010)", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => {
         fetchCount += 1;
         // After iteration 1: ENG-2 has acquired a blockedBy that points to
@@ -1611,6 +1638,7 @@ describe("runIssueQueue — mid-run queue rebuild (ADR-0010)", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => {
         fetchCount += 1;
         if (fetchCount === 1) {
@@ -1657,6 +1685,7 @@ describe("runIssueQueue — mid-run queue rebuild (ADR-0010)", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => {
         fetchCount += 1;
         if (fetchCount === 1) {
@@ -1706,6 +1735,7 @@ describe("runIssueQueue — mid-run queue rebuild (ADR-0010)", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => {
         fetchCalls += 1;
         return Promise.resolve([]);
@@ -1736,6 +1766,7 @@ describe("runIssueQueue — mid-run queue rebuild (ADR-0010)", () => {
       repoRoot: "/repo",
       config: baseConfig,
       sandboxEnv: {},
+      repoName: "tide",
       fetchSubIssues: () => {
         fetchCount += 1;
         if (fetchCount === 1) {
@@ -1795,5 +1826,49 @@ describe("runIssueQueue — mid-run queue rebuild (ADR-0010)", () => {
       "ENG-1",
       "ENG-2",
     ]);
+  });
+
+  test("PRD root: every iteration-boundary fetchSubIssues call receives the runner's repoName (ADR-0012)", async () => {
+    // The mid-run queue rebuild must apply the same `[<repoName>] `
+    // title-prefix scope filter as the initial queue build — wrong-repo
+    // and unprefixed Sub-issues are invisible to both, and a mistitled
+    // sub-issue is never absorbed by the rebuild.
+    const fetchCalls: { prdId: string; repoName: string }[] = [];
+
+    await runIssueQueue({
+      root: { kind: "prd", id: "uuid-prd", identifier: "ENG-100" },
+      orderedIssues: [
+        makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
+        makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),
+      ],
+      branch: "feature/eng",
+      baseBranch: "master",
+      linearCtx,
+      repoRoot: "/repo",
+      config: baseConfig,
+      sandboxEnv: {},
+      repoName: "widget",
+      fetchSubIssues: (_ctx, prdId, repoName) => {
+        fetchCalls.push({ prdId, repoName });
+        return Promise.resolve(
+          asSubIssues([
+            makeOrdered({ id: "uuid-1", identifier: "ENG-1" }),
+            makeOrdered({ id: "uuid-2", identifier: "ENG-2" }),
+          ])
+        );
+      },
+      fetchIssueContent: () => Promise.resolve(makeIssueContent()),
+      transitionToInProgress: () => Promise.resolve(),
+      transitionToDone: () => Promise.resolve(),
+      sandboxRun: () => Promise.resolve(makeSandboxRunResult()),
+    });
+
+    // Two iterations → two boundaries → two rebuild fetches. Each must
+    // carry the runner's `repoName` argument verbatim.
+    expect(fetchCalls).toHaveLength(2);
+    for (const c of fetchCalls) {
+      expect(c.prdId).toBe("uuid-prd");
+      expect(c.repoName).toBe("widget");
+    }
   });
 });


### PR DESCRIPTION
## 🚩 The Problem

- One Linear team backs many repos, so before this change `tide run` showed every team-wide PRD and Standalone Issue regardless of which repo the user was running in — wrong-repo work cluttered the picker and could be queued by mistake.
- Mid-run rebuilds (ADR-0010) had the same blind spot: a sub-issue added under a `[<repo>] ` PRD with the wrong title prefix would silently get absorbed into the queue at the next iteration boundary.
- An empty picker / empty queue gave no hint about *why* it was empty — the user couldn't tell whether nothing was ready, or whether their titles were missing the `[<repo>] ` prefix tide expects.

## 💡 The Solution

- **Widen** the three Linear list/fetch entry points (`listPRDs`, `listStandaloneIssues`, `fetchSubIssues`) to take a `repoName` argument and apply it as a server-side `title.startsWith("[<repoName>] ")` filter (ADR-0012). Setup/doctor operations stay repo-agnostic.
- Thread the working repo's GitHub name (`ghIdentity.repo`) through `tideRun` → `runQueueAfterPick` → `runIssueQueue` so every list call, the initial sub-issue fetch, the Standalone-Issue children-validation fetch, and every iteration-boundary rebuild apply the same prefix filter.
- **Deepen** the empty-result UX: when a list/fetch returns zero matches the user now sees a warning that names the repo, shows the exact `[<repo>] ` prefix, and points at the two recovery moves (retitle, or create via the triage / to-prd / to-issues skill).
- Export a small `repoTitlePrefix(repoName)` helper so the canonical `[<repo>] ` form (open-bracket, repo, close-bracket, single space — no whitespace tolerance) lives in one place.

## 🏗 Interface Movements

| Symbol | Old location | New location | Notes |
| --- | --- | --- | --- |
| `repoTitlePrefix` | _(did not exist)_ | `src/linear/index.ts` | New export; canonical `[<repoName>] ` builder. |
| `listPRDs(ctx, _client?)` | `src/linear/index.ts` | `src/linear/index.ts` | Widened — now `listPRDs(ctx, repoName, _client?)`. Required positional arg. |
| `listStandaloneIssues(ctx, _client?)` | `src/linear/index.ts` | `src/linear/index.ts` | Widened — now `listStandaloneIssues(ctx, repoName, _client?)`. Required positional arg. |
| `fetchSubIssues(ctx, prdId, _request?)` | `src/linear/index.ts` | `src/linear/index.ts` | Widened — now `fetchSubIssues(ctx, prdId, repoName, _request?)`. Required positional arg. GraphQL document gains `$filter: IssueFilter` and threads it into `children(... filter: $filter)`. |
| `ListPRDsIssueFilter.title?` | _(did not exist)_ | `src/linear/index.ts` | New optional `{ startsWith: string }` field. |
| `ListStandaloneIssuesFilter.title?` | _(did not exist)_ | `src/linear/index.ts` | New optional `{ startsWith: string }` field. |
| `RunIssueQueueOptions.repoName` | _(did not exist)_ | `src/runner/index.ts` | New **required** field — the working repo's GitHub name, threaded into every iteration-boundary rebuild. |
| `RunIssueQueueOptions.fetchSubIssues` | `src/runner/index.ts` | `src/runner/index.ts` | Seam signature widened to `(ctx, prdId, repoName) => Promise<SubIssue[]>`. |
| `RunOptions.listPRDs` | `src/cli/run.ts` | `src/cli/run.ts` | Seam signature widened to `(ctx, repoName) => Promise<PRD[]>`. |
| `RunOptions.listStandaloneIssues` | `src/cli/run.ts` | `src/cli/run.ts` | Seam signature widened to `(ctx, repoName) => Promise<StandaloneIssue[]>`. |
| `RunQueueAfterPickOptions.fetchSubIssues` | `src/cli/run.ts` | `src/cli/run.ts` | Seam signature widened to `(ctx, issueId, repoName) => Promise<SubIssue[]>`. |

## 📦 Package Breakdowns

<details>
<summary><code>src/cli/</code> — entry point: thread <code>ghIdentity.repo</code> into every Linear call and surface empty-result hints</summary>

- `tideRun` now passes `ghIdentity.repo` into both `listPRDs` and `listStandaloneIssues`, and into the Standalone-Issue children-validation `fetchSubIssues` call inside `runQueueAfterPick`.
- `runQueueAfterPick` passes `ghRepo.repo` into the PRD-root sub-issue fetch and forwards `repoName` to `runIssueQueue` so the runner's iteration-boundary rebuild stays in scope.
- New private `emptyListMessage(kind, repoName)` helper renders the user-facing warning shown when a PRD list, Standalone Issue list, root list, or PRD sub-issue fetch returns zero matches — names the repo, the `[<repo>] ` form, and the two recovery moves.
- `RunOptions.listPRDs`, `RunOptions.listStandaloneIssues`, and `RunQueueAfterPickOptions.fetchSubIssues` seam signatures widened to carry `repoName`; tests updated to match.

</details>

<details>
<summary><code>src/linear/</code> — list/fetch operations apply the <code>[&lt;repo&gt;] </code> title-prefix filter</summary>

- `listPRDs` and `listStandaloneIssues` accept `repoName` and add a `title: { startsWith: repoTitlePrefix(repoName) }` clause to their `issues` filter; child-count queries are deliberately *not* re-filtered (they're scoped by `parent.id.eq` and re-applying the prefix would silently drop valid sub-issue counts).
- `fetchSubIssues` accepts `repoName` and threads the prefix into the children connection via a new `$filter: IssueFilter` GraphQL variable, so a mistitled or wrong-repo sub-issue under a `[<repo>] ` PRD is invisible to both the initial queue build and the mid-run rebuild.
- New exported helper `repoTitlePrefix(repoName)` returns the canonical form; tests pin the exact byte shape (no whitespace tolerance inside the brackets, exact trailing space).
- `ListPRDsIssueFilter` / `ListStandaloneIssuesFilter` gain an optional `title?: { startsWith: string }` field.

</details>

<details>
<summary><code>src/runner/</code> — iteration-boundary rebuild stays scoped to the working repo</summary>

- `RunIssueQueueOptions` gains a required `repoName: string` field; `runIssueQueue` destructures it and threads it into `rebuildQueueAtBoundary`.
- `rebuildQueueAtBoundary` and the `fetchSubIssues` seam now accept `repoName` and forward it on every rebuild call — this closes the mid-run blind spot where a wrong-repo sub-issue could be absorbed at iteration boundaries.
- New private `emptySubIssueRebuildMessage(repoName)` warning fires when a rebuild returns zero matches; the runner keeps the previous boundary's queue and continues, but the user now sees why the rebuild was empty.

</details>

## 🧹 Housekeeping & Secondary Changes

- Removes the stray `.sandcastle` symlink at the repo root (it pointed at `.tide` and is no longer needed now that the sandcastle bridge in setup/doctor manages this).
