### PR TITLE
feat(pr-submission): render PR title host-side as [<linear-id>] <root-title>

### DIFF
--- a/src/pr-submission/index.test.ts
+++ b/src/pr-submission/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import {
   buildPrPromptArgs,
+  buildPrTitle,
   countCommitsAhead,
   resolveBaseBranch,
   runPrSubmission,
@@ -233,8 +234,7 @@ describe("runPrSubmission", () => {
     expect(receivedRunOptions.prompt).not.toContain(
       "https://github.com/acme/widget/issues/"
     );
-    // The bundled rich template ships all six sections plus a Conventional
-    // Commits title rule.
+    // The bundled rich template ships all five body sections.
     expect(receivedRunOptions.prompt).toContain("🚩 The Problem");
     expect(receivedRunOptions.prompt).toContain("💡 The Solution");
     expect(receivedRunOptions.prompt).toContain("🏗 Interface Movements");
@@ -242,7 +242,19 @@ describe("runPrSubmission", () => {
     expect(receivedRunOptions.prompt).toContain(
       "🧹 Housekeeping & Secondary Changes"
     );
-    expect(receivedRunOptions.prompt).toContain("Conventional Commits");
+    // The `# Title` section reduces to a one-line directive wiring the
+    // host-computed `{{PR_TITLE}}` (ADR-0013). Conventional Commits and the
+    // type/scope/subject vocabulary are gone.
+    expect(receivedRunOptions.prompt).toContain(
+      "Use this exact title: [MEC-123] PRD: example feature"
+    );
+    expect(receivedRunOptions.prompt).not.toContain("Conventional Commits");
+    expect(receivedRunOptions.prompt).not.toContain("<type>(<scope>)");
+    expect(receivedRunOptions.prompt).not.toContain("<subject>");
+    // The example `gh pr create` substitutes the title in single-quoted form.
+    expect(receivedRunOptions.prompt).toContain(
+      "--title '[MEC-123] PRD: example feature'"
+    );
     // Ordered sub-issue list shows up in the rendered prompt.
     expect(receivedRunOptions.prompt).toContain("#8 Foundation tracer");
     expect(receivedRunOptions.prompt).toContain("#9 Pre-flight clack confirm");
@@ -334,6 +346,7 @@ describe("buildPrPromptArgs", () => {
     });
     expect(Object.keys(args).sort()).toEqual(
       [
+        "PR_TITLE",
         "REPO_NAME",
         "REPO_OWNER",
         "ROOT_ID",
@@ -351,6 +364,16 @@ describe("buildPrPromptArgs", () => {
     expect(args.TARGET_BRANCH).toBe("master");
     expect(args.REPO_OWNER).toBe("acme");
     expect(args.REPO_NAME).toBe("widget");
+    expect(args.PR_TITLE).toBe("[MEC-123] PRD: example feature");
+  });
+
+  it("computes PR_TITLE with the working repo's `[<repoName>] ` prefix stripped", () => {
+    const args = buildPrPromptArgs({
+      ...baseInput,
+      rootTitle: "[widget] PRD: example feature",
+      subIssues: [],
+    });
+    expect(args.PR_TITLE).toBe("[MEC-123] PRD: example feature");
   });
 
   it("omits the entire `Sub-issues addressed` block when subIssues is empty (Standalone Issue root)", () => {
@@ -409,5 +432,84 @@ describe("buildPrPromptArgs", () => {
     expect(args.SUB_ISSUES_BLOCK).toBe(
       "- Sub-issues addressed (in order):\n- #1 spaced"
     );
+  });
+});
+
+describe("buildPrTitle", () => {
+  it("composes `[<rootIdentifier>] <root-title>` for a bare title with no Repo prefix", () => {
+    expect(
+      buildPrTitle({
+        rootIdentifier: "PER-76",
+        rootTitle: "add linear issue prefix to PR title",
+        repoName: "tide",
+      })
+    ).toBe("[PER-76] add linear issue prefix to PR title");
+  });
+
+  it("strips the working repo's `[<repoName>] ` prefix before composing the title", () => {
+    expect(
+      buildPrTitle({
+        rootIdentifier: "PER-76",
+        rootTitle: "[tide] add linear issue prefix to PR title",
+        repoName: "tide",
+      })
+    ).toBe("[PER-76] add linear issue prefix to PR title");
+  });
+
+  it("is idempotent: titles already lacking the Repo prefix pass through unchanged", () => {
+    const first = buildPrTitle({
+      rootIdentifier: "PER-76",
+      rootTitle: "add linear issue prefix to PR title",
+      repoName: "tide",
+    });
+    const second = buildPrTitle({
+      rootIdentifier: "PER-76",
+      rootTitle: first.replace(/^\[PER-76\] /, ""),
+      repoName: "tide",
+    });
+    expect(second).toBe(first);
+  });
+
+  it("preserves a non-matching bracketed prefix (`[other] ` where other !== repoName)", () => {
+    expect(
+      buildPrTitle({
+        rootIdentifier: "PER-76",
+        rootTitle: "[other] add linear issue prefix to PR title",
+        repoName: "tide",
+      })
+    ).toBe("[PER-76] [other] add linear issue prefix to PR title");
+  });
+
+  it("collapses internal whitespace (newlines, tabs, multiple spaces) and trims, before composing", () => {
+    expect(
+      buildPrTitle({
+        rootIdentifier: "PER-76",
+        rootTitle: "  add\tlinear\nissue   prefix  ",
+        repoName: "tide",
+      })
+    ).toBe("[PER-76] add linear issue prefix");
+  });
+
+  it("strips Repo prefix even when whitespace inside the title was originally awkward", () => {
+    // Sanitization runs before the prefix strip, so a title like
+    // `[tide]\nfoo` collapses to `[tide] foo` and then gets stripped to
+    // `foo`. Matches the byte-for-byte form the triage skill writes.
+    expect(
+      buildPrTitle({
+        rootIdentifier: "PER-76",
+        rootTitle: "[tide]\nfoo",
+        repoName: "tide",
+      })
+    ).toBe("[PER-76] foo");
+  });
+
+  it("strips the prefix only once — never double-strips a `[<repo>] [<repo>] ` chain", () => {
+    expect(
+      buildPrTitle({
+        rootIdentifier: "PER-76",
+        rootTitle: "[tide] [tide] foo",
+        repoName: "tide",
+      })
+    ).toBe("[PER-76] [tide] foo");
   });
 });

--- a/src/pr-submission/index.ts
+++ b/src/pr-submission/index.ts
@@ -29,6 +29,7 @@ import {
 import { docker } from "@ai-hero/sandcastle/sandboxes/docker";
 import type { TideConfig } from "../config-loader/index.ts";
 import type { GhRepo } from "../github/index.ts";
+import { repoTitlePrefix } from "../linear/index.ts";
 import { DONE_SIGNAL, type SandboxRunFn } from "../runner/index.ts";
 
 export interface ShellResult {
@@ -172,10 +173,11 @@ export async function resolveBaseBranch(
 
 // Bundled, interface-emphasizing PR template. Renders five body sections
 // (🚩 The Problem · 💡 The Solution · 🏗 Interface Movements · 📦 Package
-// Breakdowns · 🧹 Housekeeping & Secondary Changes) plus a Conventional
-// Commits title rule. The agent classifies changed identifiers as
-// public/private using the rules in the `Interface Movements` section and
-// populates the table only with public surface that actually moved.
+// Breakdowns · 🧹 Housekeeping & Secondary Changes) and wires a host-
+// computed `{{PR_TITLE}}` into the `gh pr create --title` argument. The
+// agent classifies changed identifiers as public/private using the rules in
+// the `Interface Movements` section and populates the table only with public
+// surface that actually moved.
 //
 // No closing magic word is emitted (neither GitHub `Closes #` nor Linear
 // `Fixes`). The PR↔PRD link is the branch name alone — Linear's GitHub
@@ -194,13 +196,7 @@ The current working branch is \`{{SOURCE_BRANCH}}\` (already pushed to origin). 
 
 # Title
 
-Use Conventional Commits: \`<type>(<scope>): <subject>\`.
-
-- \`<type>\` is one of \`feat\`, \`fix\`, \`chore\`, \`docs\`, \`refactor\`, \`test\`, \`build\`, \`ci\`, \`perf\`, \`style\`. Pick the type that best matches the headline change in the diff.
-- \`<scope>\` is the package or area touched. Optional — omit it for multi-package PRDs that span scopes.
-- \`<subject>\` is a concise, imperative-mood summary derived from the diff.
-
-Examples: \`feat(runner): add per-iteration timeout\` or \`refactor: extract pr-submission module\`.
+Use this exact title: {{PR_TITLE}}
 
 # Body — sections in this exact order
 
@@ -259,7 +255,7 @@ Run \`gh pr create\` against the right base. A safe invocation:
       --repo {{REPO_OWNER}}/{{REPO_NAME}} \\
       --base {{TARGET_BRANCH}} \\
       --head {{SOURCE_BRANCH}} \\
-      --title "<your title here>" \\
+      --title '{{PR_TITLE}}' \\
       --body-file <(cat <<'PR_BODY_EOF'
     <your fully-rendered body here, with no closing magic word>
     PR_BODY_EOF
@@ -298,6 +294,41 @@ function renderSubIssuesBlock(subs: readonly SubIssueRef[]): string {
   return `- Sub-issues addressed (in order):\n${bullets}`;
 }
 
+export interface BuildPrTitleInput {
+  /** Linear root identifier (e.g. "PER-76"). */
+  rootIdentifier: string;
+  /** Root issue's Linear title. May carry the leading `[<repoName>] ` Repo
+   * prefix; if so, that prefix is stripped exactly once. */
+  rootTitle: string;
+  /** GitHub repo name. Used to recognise the working repo's own Repo prefix
+   * for stripping; non-matching bracketed prefixes are preserved. */
+  repoName: string;
+}
+
+/**
+ * Pure: compute the deterministic GitHub PR title `[<rootIdentifier>] <root-title>`.
+ *
+ * `rootTitle` is first whitespace-collapsed and trimmed (matching the
+ * existing `sanitizeInline` treatment applied to other prompt-substituted
+ * titles), then the working repo's own `[<repoName>] ` Repo prefix is
+ * stripped exactly once if present. A non-matching bracketed prefix
+ * (e.g. `[other] ` where `other !== repoName`) is preserved — only the
+ * working repo's prefix is removed, so the strip is symmetric with the
+ * triage / to-prd / to-issues skills that write the prefix at issue-
+ * creation time (ADR-0012). Idempotent: a `rootTitle` already lacking the
+ * prefix passes through unchanged.
+ *
+ * See ADR-0013.
+ */
+export function buildPrTitle(input: BuildPrTitleInput): string {
+  const sanitized = sanitizeInline(input.rootTitle);
+  const prefix = repoTitlePrefix(input.repoName);
+  const stripped = sanitized.startsWith(prefix)
+    ? sanitized.slice(prefix.length)
+    : sanitized;
+  return `[${input.rootIdentifier}] ${stripped}`;
+}
+
 /**
  * Pure: build the `{{KEY}}` substitution map for the bundled PR prompt
  * template. Returns numbers as numbers and strings as strings so the
@@ -306,6 +337,11 @@ function renderSubIssuesBlock(subs: readonly SubIssueRef[]): string {
  * breaking the surrounding markdown. The "Sub-issues addressed" block is
  * rendered conditionally — present for PRD roots (non-empty subIssues),
  * omitted for Standalone Issue roots (empty subIssues).
+ *
+ * `PR_TITLE` is the host-computed deterministic GitHub PR title (ADR-0013):
+ * `[<rootIdentifier>] <root-title>`, with the leading `[<repoName>] ` Repo
+ * prefix stripped if present. The agent runs `gh pr create --title` with
+ * the substituted value verbatim.
  */
 export function buildPrPromptArgs(
   input: BuildPrPromptArgsInput
@@ -319,6 +355,11 @@ export function buildPrPromptArgs(
     REPO_OWNER: input.repoOwner,
     REPO_NAME: input.repoName,
     SUB_ISSUES_BLOCK: renderSubIssuesBlock(input.subIssues),
+    PR_TITLE: buildPrTitle({
+      rootIdentifier: input.rootIdentifier,
+      rootTitle: input.rootTitle,
+      repoName: input.repoName,
+    }),
   };
 }
 


### PR DESCRIPTION
## 🚩 The Problem

- PR titles were left to the in-sandbox agent under a free-form Conventional Commits rule, so the format drifted between iterations and the resulting titles carried no link back to the Linear root.
- Reviewers scanning a list of PRs had no at-a-glance way to map a PR to its driving Linear issue without clicking through and inspecting the branch name.
- Titles authored by the agent could re-introduce the working repo's own `[<repoName>] ` prefix that the triage / to-prd / to-issues skills already write into Linear titles (ADR-0012), producing redundant `[tide] [tide] …` chains.
- The bundled template's title section duplicated commit-style guidance the host could compute deterministically, leaving room for per-run variance on something that should be mechanical.

## 💡 The Solution

- **Extract** the title computation into a new pure helper `buildPrTitle({ rootIdentifier, rootTitle, repoName })` in `src/pr-submission/`, returning `[<rootIdentifier>] <root-title>` with the working repo's `[<repoName>] ` prefix stripped exactly once.
- **Widen** the prompt-arg substitution map (`buildPrPromptArgs`) with a new `PR_TITLE` key so the bundled template can interpolate the host-computed title verbatim.
- Collapse the template's `# Title` section to a one-line directive (`Use this exact title: {{PR_TITLE}}`) and substitute the title into the example `gh pr create --title '{{PR_TITLE}}'` invocation, so the agent runs the host-decided title byte-for-byte.
- Sanitization (whitespace collapse + trim) runs before the prefix strip, so awkwardly-whitespaced Linear titles like `[tide]\nfoo` normalise to `[PER-76] foo`. Implements ADR-0013.

## 🏗 Interface Movements

| Symbol | Old location | New location | Notes |
| --- | --- | --- | --- |
| `buildPrTitle` | _(did not exist)_ | `src/pr-submission/index.ts` (exported) | New pure helper. Composes `[<rootIdentifier>] <root-title>`; strips the working repo's `[<repoName>] ` prefix exactly once; idempotent. |
| `BuildPrTitleInput` | _(did not exist)_ | `src/pr-submission/index.ts` (exported) | Input shape for `buildPrTitle`. |
| `PR_TITLE` (prompt-arg key) | _(did not exist)_ | Returned by `buildPrPromptArgs` in `src/pr-submission/index.ts` | New `{{PR_TITLE}}` substitution key consumed by the bundled PR template. |
| Bundled PR template `# Title` section | Conventional Commits rule (`<type>(<scope>): <subject>`) | `src/pr-submission/index.ts` template literal | Reduced to `Use this exact title: {{PR_TITLE}}`. Conventional Commits vocabulary removed. |
| Bundled PR template `gh pr create` example | `--title "<your title here>"` | `src/pr-submission/index.ts` template literal | Now `--title '{{PR_TITLE}}'` (single-quoted, host-substituted). |

## 📦 Package Breakdowns

<details>
<summary><code>src/pr-submission/</code> — host-compute the PR title and wire it into the bundled prompt template</summary>

- Adds `buildPrTitle` (and its `BuildPrTitleInput` shape) as a pure exported helper that composes `[<rootIdentifier>] <root-title>`, sanitising whitespace and stripping the working repo's `[<repoName>] ` Repo prefix exactly once via `repoTitlePrefix` from `src/linear/`.
- Extends `buildPrPromptArgs` to populate a new `PR_TITLE` key alongside the existing substitution keys; consumers see one extra key in the returned record.
- Collapses the template's `# Title` section from a multi-bullet Conventional Commits rule down to a single directive (`Use this exact title: {{PR_TITLE}}`) and substitutes `--title '{{PR_TITLE}}'` into the example `gh pr create` invocation.
- Updates the inline doc comment on the template to reflect that the host now wires the title (no more "plus a Conventional Commits title rule").

</details>

<details>
<summary><code>src/pr-submission/index.test.ts</code> — cover the new helper and the template wiring</summary>

- Adds a `describe("buildPrTitle", …)` block exercising: bare title pass-through, working-repo prefix strip, idempotency, preservation of non-matching bracketed prefixes (`[other] …`), whitespace collapsing/trimming, awkward-whitespace + prefix interaction, and the single-strip guarantee against `[tide] [tide] …` chains.
- Extends the existing `runPrSubmission` rendered-prompt assertions: the prompt now contains `Use this exact title: [MEC-123] PRD: example feature` and `--title '[MEC-123] PRD: example feature'`, and no longer mentions Conventional Commits, `<type>(<scope>)`, or `<subject>`.
- Extends the existing `buildPrPromptArgs` assertions: the returned record now includes `PR_TITLE`, equal to `[MEC-123] PRD: example feature`, with a separate case proving the working repo's `[widget] ` prefix is stripped from `rootTitle` before composition.

</details>

## 🧹 Housekeeping & Secondary Changes

_(none)_
